### PR TITLE
global: several bug fixes

### DIFF
--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -39,6 +39,8 @@ class InvenioCli(object):
         :param flavour: Flavour name.
         """
         self.cwd = None
+        self.flavour = None
+        self.name = None
         self.config = ConfigParser()
         self.config.read(CONFIG_FILENAME)
 
@@ -58,6 +60,7 @@ class InvenioCli(object):
                 exit(1)
             try:
                 self.cwd = self.config['cli']['cwd']
+                self.name = self.cwd.split('/')[-1] if self.cwd else None
             except KeyError:
                 logging.debug('Working directory not configured')
         elif flavour:
@@ -148,7 +151,7 @@ def build(cli_obj, base, app, pre, dev, lock):
                 path=cli_obj.cwd,
                 dockerfile='Dockerfile.base',
                 tag='{project_name}-base:latest'.format(
-                    project_name=cli_obj.cwd),
+                    project_name=cli_obj.name)
             )
         if app:
             print('Building {flavour} app docker image...'.format(
@@ -160,7 +163,7 @@ def build(cli_obj, base, app, pre, dev, lock):
                 path=cli_obj.cwd,
                 dockerfile='Dockerfile',
                 tag='{project_name}:latest'.format(
-                    project_name=cli_obj.cwd),
+                    project_name=cli_obj.name)
             )
         print('Creating full services...')
         DockerCompose.create_containers(

--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -107,10 +107,10 @@ def init(cli_obj):
 @click.pass_obj
 @click.option('--dev/--prod', default=True, is_flag=True,
               help='Which environment to build, it defaults to development')
-@click.option('--base', default=False, is_flag=True,
+@click.option('--base/--skip-base', default=True, is_flag=True,
               help='If specified, it will build the base docker image ' +
                    '(not compatible with --dev)')
-@click.option('--app', default=False, is_flag=True,
+@click.option('--app/--skip-app', default=True, is_flag=True,
               help='If specified, it will build the application docker ' +
                    'image (not compatible with --dev)')
 @click.option('--pre', default=False, is_flag=True,

--- a/invenio_cli/utils.py
+++ b/invenio_cli/utils.py
@@ -47,7 +47,8 @@ class DockerCompose(object):
 
     def destroy_containers(dev, cwd):
         """Stop and remove all containers, volumes and images."""
-        command = ['docker-compose', '-f', 'docker-compose.yml', 'down']
+        command = ['docker-compose', '-f', 'docker-compose.yml',
+                   'down', '--volumes']
         if dev:
             command[2] = 'docker-compose.dev.yml'
 

--- a/invenio_cli/utils.py
+++ b/invenio_cli/utils.py
@@ -20,19 +20,19 @@ class DockerCompose(object):
     def create_containers(dev, cwd):
         """Create images according to the specified environment."""
         command = ['docker-compose',
-                   '-f', 'docker-compose.yml', 'up', '--no-start']
+                   '-f', 'docker-compose.full.yml', 'up', '--no-start']
         if dev:
-            command[2] = 'docker-compose.dev.yml'
+            command[2] = 'docker-compose.yml'
 
         subprocess.call(command, cwd=cwd)
 
     def start_containers(dev, cwd, bg):
         """Start containers according to the specified environment."""
         command = ['docker-compose',
-                   '-f', 'docker-compose.yml', 'up', '--no-recreate']
+                   '-f', 'docker-compose.full.yml', 'up', '--no-recreate']
 
         if dev:
-            command[2] = 'docker-compose.dev.yml'
+            command[2] = 'docker-compose.yml'
 
         if bg:
             command.append('-d')
@@ -47,10 +47,10 @@ class DockerCompose(object):
 
     def destroy_containers(dev, cwd):
         """Stop and remove all containers, volumes and images."""
-        command = ['docker-compose', '-f', 'docker-compose.yml',
+        command = ['docker-compose', '-f', 'docker-compose.full.yml',
                    'down', '--volumes']
         if dev:
-            command[2] = 'docker-compose.dev.yml'
+            command[2] = 'docker-compose.yml'
 
         subprocess.call(command, cwd=cwd)
 


### PR DESCRIPTION
- When executing the build in "semi-prod" the app and the base images needed to be explicitly requested (i.e. add ``--base`` and ``--app`` flags). It is better to have them by default and allow ``skip`` on them.

- There was a bug on the image name, it was containing the whole cwd path instead of just the project name. A new property was added.

- The destroy command was not removing the volumes. Kudos to @fenekku, for the reminder :)