### PR TITLE
Several bug fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ env:
   - REQUIREMENTS=devel
 
 python:
-  - "2.7"
   - "3.5"
+  - "3.6"
 
 before_install:
   - "nvm install 6; nvm use 6"
@@ -57,6 +57,6 @@ deploy:
   distributions: "compile_catalog sdist bdist_wheel"
   on:
     tags: true
-    python: "3.5"
+    python: "3.6"
     repo: inveniosoftware/invenio-cli
     condition: $DEPLOY = true

--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (C) 2019 CERN.
-Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+Copyright (C) 2019 Northwestern University.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/babel.ini
+++ b/babel.ini
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/examplesapp.rst
+++ b/docs/examplesapp.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,6 +1,6 @@
 ..
     Copyright (C) 2019 CERN.
-    Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+    Copyright (C) 2019 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/examples/app.py
+++ b/examples/app.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/__init__.py
+++ b/invenio_cli/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -133,7 +133,7 @@ def build(cli_obj, base, app, pre, dev, lock):
         subprocess.call(['/bin/bash', 'scripts/bootstrap', '--dev'])
 
         print('Creating development services...')
-        DockerCompose.create_containers(dev=True)
+        DockerCompose.create_images(dev=True)
     else:
         if base:
             print('Building {flavour} base docker image...'.format(
@@ -157,7 +157,7 @@ def build(cli_obj, base, app, pre, dev, lock):
                     project_name=cli_obj.name)
             )
         print('Creating full services...')
-        DockerCompose.create_containers(dev=False)
+        DockerCompose.create_images(dev=False)
 
 
 @cli.command()

--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -18,6 +18,7 @@ import click
 import docker
 from pathlib import Path
 from cookiecutter.main import cookiecutter
+from cookiecutter.exceptions import OutputDirExistsException
 
 from .utils import DockerCompose, cookiecutter_repo
 
@@ -84,24 +85,21 @@ def init(cli_obj):
     """Initializes the application according to the chosen flavour."""
     print('Initializing {flavour} application...'.format(
         flavour=cli_obj.flavour))
-    context = cookiecutter(**cookiecutter_repo(cli_obj.flavour))
-    config = cli_obj.config
+    try:
+        context = cookiecutter(**cookiecutter_repo(cli_obj.flavour))
+        config = cli_obj.config
 
-    file_fullpath = Path(context) / CONFIG_FILENAME
+        file_fullpath = Path(context) / CONFIG_FILENAME
 
-    with open(file_fullpath, 'w') as configfile:
-        # Read config file
-        config.read(CONFIG_FILENAME)
-
-        if CLI_SECTION in config.sections():
-            logging.error('An invenio-cli configuration file ' +
-                          '({config})'.format(config=CONFIG_FILENAME) +
-                          'already exists. Cannot override')
-
-        else:
+        with open(file_fullpath, 'w') as configfile:
+            # Read config file
+            config.read(CONFIG_FILENAME)
             config[CLI_SECTION] = {}
             config[CLI_SECTION][FLAVOUR_ITEM] = cli_obj.flavour
             config.write(configfile)
+
+    except OutputDirExistsException as e:
+        print(str(e))
 
 
 @cli.command()

--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -13,12 +13,12 @@ import os
 import signal
 import subprocess
 import sys
+from pathlib import Path
 
 import click
 import docker
-from pathlib import Path
-from cookiecutter.main import cookiecutter
 from cookiecutter.exceptions import OutputDirExistsException
+from cookiecutter.main import cookiecutter
 
 from .utils import DockerCompose, cookiecutter_repo
 
@@ -60,7 +60,8 @@ class InvenioCli(object):
             except KeyError:
                 logging.error('Flavour not configured')
                 exit(1)
-            # FIXME: obtain cookicutter config along with project name into self.name
+            # FIXME: obtain cookicutter config along with project
+            # name into self.name
         elif flavour:
             # There is no .invenio file but the flavour was provided via CLI
             self.flavour = flavour

--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/config.py
+++ b/invenio_cli/config.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/ext.py
+++ b/invenio_cli/ext.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/templates/invenio_cli/base.html
+++ b/invenio_cli/templates/invenio_cli/base.html
@@ -1,6 +1,6 @@
 {#
   Copyright (C) 2019 CERN.
-  Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+  Copyright (C) 2019 Northwestern University.
 
   Invenio-Cli is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/templates/invenio_cli/index.html
+++ b/invenio_cli/templates/invenio_cli/index.html
@@ -1,6 +1,6 @@
 {#
   Copyright (C) 2019 CERN.
-  Copyright (C) 2019 Northwestern University, Galter Health Sciences Library & Learning Center.
+  Copyright (C) 2019 Northwestern University.
 
   Invenio-Cli is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_cli/translations/en/LC_MESSAGES/messages.po
@@ -1,5 +1,6 @@
 # English translations for invenio-cli.
 # Copyright (C) 2019 CERN
+# Copyright (C) 2019 Northwestern University.
 # This file is distributed under the same license as the invenio-cli
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2019.

--- a/invenio_cli/translations/messages.pot
+++ b/invenio_cli/translations/messages.pot
@@ -1,5 +1,6 @@
 # Translations template for invenio-cli.
 # Copyright (C) 2019 CERN
+# Copyright (C) 2019 Northwestern University.
 # This file is distributed under the same license as the invenio-cli
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2019.

--- a/invenio_cli/utils.py
+++ b/invenio_cli/utils.py
@@ -2,8 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/utils.py
+++ b/invenio_cli/utils.py
@@ -17,16 +17,16 @@ class DockerCompose(object):
     """Utility class to interact with docker-compose."""
 
     # FIXME: Change name to create_images
-    def create_containers(dev, cwd):
+    def create_containers(dev):
         """Create images according to the specified environment."""
         command = ['docker-compose',
                    '-f', 'docker-compose.full.yml', 'up', '--no-start']
         if dev:
             command[2] = 'docker-compose.yml'
 
-        subprocess.call(command, cwd=cwd)
+        subprocess.call(command)
 
-    def start_containers(dev, cwd, bg):
+    def start_containers(dev, bg):
         """Start containers according to the specified environment."""
         command = ['docker-compose',
                    '-f', 'docker-compose.full.yml', 'up', '--no-recreate']
@@ -36,23 +36,23 @@ class DockerCompose(object):
 
         if bg:
             command.append('-d')
-            subprocess.call(command, cwd=cwd)
+            subprocess.call(command, )
         else:
-            subprocess.Popen(command, cwd=cwd,
+            subprocess.Popen(command,
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    def stop_containers(cwd):
+    def stop_containers():
         """Stop currently running containers."""
-        subprocess.call(['docker-compose', 'stop'], cwd=cwd)
+        subprocess.call(['docker-compose', 'stop'])
 
-    def destroy_containers(dev, cwd):
+    def destroy_containers(dev):
         """Stop and remove all containers, volumes and images."""
         command = ['docker-compose', '-f', 'docker-compose.full.yml',
                    'down', '--volumes']
         if dev:
             command[2] = 'docker-compose.yml'
 
-        subprocess.call(command, cwd=cwd)
+        subprocess.call(command)
 
 
 def cookiecutter_repo(flavor):

--- a/invenio_cli/utils.py
+++ b/invenio_cli/utils.py
@@ -15,8 +15,7 @@ import subprocess
 class DockerCompose(object):
     """Utility class to interact with docker-compose."""
 
-    # FIXME: Change name to create_images
-    def create_containers(dev):
+    def create_images(dev):
         """Create images according to the specified environment."""
         command = ['docker-compose',
                    '-f', 'docker-compose.full.yml', 'up', '--no-start']

--- a/invenio_cli/version.py
+++ b/invenio_cli/version.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/views.py
+++ b/invenio_cli/views.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/setup.py
+++ b/setup.py
@@ -98,10 +98,8 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Development Status :: 3 - Alpha',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/tests/test_examples_app.py
+++ b/tests/test_examples_app.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/tests/test_invenio_scripts.py
+++ b/tests/test_invenio_scripts.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
Changes:

- Change NU copyright string across the module.
- Modify config file location. The `.invinio` configuration file should be created inside the project folder. This would allow creation of multiple projects using the CLI while still being in the same parent directory. The caveat is that for later commands the user needs to go inside the project folder (which is somehow desired so it is explicit which project is building/running/destroying).
- Catch the exception if the folder already exists. Hopefully, the fail will be faster in upcoming cookicutter versions (see https://github.com/cookiecutter/cookiecutter/issues/821)

Closes https://github.com/inveniosoftware/invenio-cli/issues/35
Closes https://github.com/inveniosoftware/invenio-cli/issues/20
Closes https://github.com/inveniosoftware/invenio-cli/issues/21