### PR TITLE
demo: add command to create demo records and fix prod setup

### DIFF
--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -342,7 +342,7 @@ def upgrade(log_level, verbose):
 @click.option('--verbose', default=False, is_flag=True, required=False,
               help='Verbose mode will show all logs in the console.')
 def demo(dev, log_level, verbose):
-    """Upgrades the current application to the specified newer version."""
+    """Populates instance with demo records."""
     # Create config object
     invenio_cli = InvenioCli(
         loglevel=LEVELS[log_level],
@@ -350,4 +350,5 @@ def demo(dev, log_level, verbose):
     )
     docker_compose = DockerHelper(dev=dev, loglevel=invenio_cli.loglevel,
                                   logfile=invenio_cli.logfile)
-    populate_demo_records(docker_compose, invenio_cli.verbose)
+    populate_demo_records(dev, docker_compose, invenio_cli.verbose,
+                          invenio_cli.project_shortname)

--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -19,7 +19,7 @@ from cookiecutter.exceptions import OutputDirExistsException
 from cookiecutter.main import cookiecutter
 
 from .helpers import CookiecutterConfig, DockerHelper, LogPipe, bootstrap, \
-    get_created_files
+    get_created_files, populate_demo_records
 from .helpers import server as scripts_server
 from .helpers import setup as scripts_setup
 from .helpers import update_statics
@@ -332,3 +332,22 @@ def upgrade(log_level, verbose):
     click.secho('Upgrading server for {flavour} application...'
                 .format(flavour=invenio_cli.flavour), fg='green')
     click.secho('ERROR: Not supported yet...', fg='red')
+
+
+@cli.command()
+@click.option('--dev/--prod', default=True, is_flag=True,
+              help='Which environment to build, it defaults to development')
+@click.option('--log-level', required=False, default='warning',
+              type=click.Choice(list(LEVELS.keys()), case_sensitive=False))
+@click.option('--verbose', default=False, is_flag=True, required=False,
+              help='Verbose mode will show all logs in the console.')
+def demo(dev, log_level, verbose):
+    """Upgrades the current application to the specified newer version."""
+    # Create config object
+    invenio_cli = InvenioCli(
+        loglevel=LEVELS[log_level],
+        verbose=verbose
+    )
+    docker_compose = DockerHelper(dev=dev, loglevel=invenio_cli.loglevel,
+                                  logfile=invenio_cli.logfile)
+    populate_demo_records(docker_compose, invenio_cli.verbose)

--- a/invenio_cli/helpers/__init__.py
+++ b/invenio_cli/helpers/__init__.py
@@ -13,4 +13,5 @@ from .cookicutter_config import CookiecutterConfig
 from .docker_helper import DockerHelper
 from .filesystem import get_created_files
 from .log import LogPipe
-from .scripts import bootstrap, server, setup, update_statics
+from .scripts import bootstrap, populate_demo_records, server, setup, \
+    update_statics

--- a/invenio_cli/helpers/cookicutter_config.py
+++ b/invenio_cli/helpers/cookicutter_config.py
@@ -31,7 +31,7 @@ class CookiecutterConfig(object):
             repo = {
                 'template': 'https://github.com/inveniosoftware/' +
                             'cookiecutter-invenio-rdm.git',
-                'checkout': 'v1.0.0a2'
+                'checkout': 'v1.0.0a3'
             }
             self.template = 'cookiecutter-invenio-rdm.json'
             return repo

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -124,7 +124,7 @@ class DockerHelper(object):
         dc_version = groups.group(0)
 
         if dc_version < DOCKER_COMPOSE_VERSION_DASH:
-            return re.sub(r'[^-_a-z0-9]', '', project_shortname)
+            return re.sub(r'[^a-z0-9]', '', project_shortname)
         else:
             return project_shortname
 

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -140,3 +140,15 @@ class DockerHelper(object):
         with open('tmp.tar', 'rb') as fin:
             data = io.BytesIO(fin.read())
             container.put_archive(dst_path, data)
+
+    def execute_cli_command(self, project_shortname, command):
+        """Execute an invenio CLI command in the API container."""
+        container_name = '{}_web-api_1'.format(
+            self._normalize_name(project_shortname))
+        container = self.docker_client.containers.get(container_name)
+
+        # TODO: Implement loggin and verbosity
+        status = container.exec_run(
+            cmd='/bin/bash -c "{}"'.format(command),
+            user='invenio',
+            tty=True)

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -118,6 +118,7 @@ class DockerHelper(object):
                                               stdout=subprocess.PIPE)
 
         dc_version_string = dc_version_command.communicate()[0]
+        dc_version_string = dc_version_string.decode("utf-8").strip()
 
         groups = re.search(r'1.[0-9]*.[0-9]*', dc_version_string)
         dc_version = groups.group(0)

--- a/invenio_cli/helpers/scripts.py
+++ b/invenio_cli/helpers/scripts.py
@@ -266,19 +266,22 @@ def setup(dev=True, force=False, docker_helper=None,
           loglevel=logging.WARN, logfile='invenio-cli.log'):
     """Bootstrap server."""
     click.secho('Setting up server...', fg='green')
-    cli = create_cli()
-    runner = current_app.test_cli_runner()
 
     click.secho("Starting containers...", fg="green")
     docker_helper.start_containers()
     time.sleep(60)  # Give time to the containers to start properly
 
     if dev:
+        cli = create_cli()
+        runner = current_app.test_cli_runner()
         _setup_dev(force, cli, runner, verbose, loglevel, logfile)
     else:
-        _setup_prod(force, docker_helper, project_shortname)
+        _setup_prod(force, docker_helper, project_shortname, loglevel,
+                    logfile)
 
+    click.secho("Stopping containers...", fg="green")
     docker_helper.stop_containers()
+    time.sleep(30)
 
 
 ##########
@@ -296,7 +299,7 @@ def _server_dev(docker_helper, loglevel, logfile, verbose):
         os.kill(worker.pid, signal.SIGTERM)
         # Stop containers
         docker_helper.stop_containers()
-        time.sleep(10)  # Allow last logs to get into the file
+        time.sleep(30)  # Allow last logs to get into the file
         # Close logging pipe
         logpipe.close()
         click.secho("Server and worker stopped...", fg="green")
@@ -333,8 +336,9 @@ def server(dev=True, docker_helper=None, project_shortname='invenio-rdm',
     else:
         click.secho("Starting docker containers. " +
                     "It might take up to a minute.", fg="green")
-        click.secho("Use --stop to stop server.", fg="green")
         docker_helper.start_containers()
+        click.secho("Containers started use --stop to stop server.",
+                    fg="green")
         time.sleep(60)
 
 

--- a/invenio_cli/helpers/scripts.py
+++ b/invenio_cli/helpers/scripts.py
@@ -343,7 +343,7 @@ def server(dev=True, docker_helper=None, project_shortname='invenio-rdm',
 
 
 @with_appcontext
-def populate_demo_records(docker_helper, verbose):
+def populate_demo_records(dev, docker_helper, verbose, project_shortname):
     """Add demo records into the instance."""
     # FIXME: Needs to execute in docker container if "prod"
     click.secho('Setting up server...', fg='green')
@@ -352,10 +352,16 @@ def populate_demo_records(docker_helper, verbose):
 
     click.secho("Starting containers...", fg="green")
     docker_helper.start_containers()
-    time.sleep(10)  # Give time to the containers to start properly
+    time.sleep(60)  # Give time to the containers to start properly
 
-    run_command(cli, runner, 'rdm-records demo',
-                message="Populating instance with demo records...",
-                verbose=verbose)
+    if dev:
+        run_command(cli, runner, 'rdm-records demo',
+                    message="Populating instance with demo records...",
+                    verbose=verbose)
+    else:
+        click.secho("Populating instance with demo records...", fg="green")
+        docker_helper.execute_cli_command(
+            project_shortname, 'invenio rdm-records demo')
 
     docker_helper.stop_containers()
+    time.sleep(30)

--- a/invenio_cli/helpers/scripts.py
+++ b/invenio_cli/helpers/scripts.py
@@ -291,3 +291,26 @@ def server(dev=True, docker_helper=None, project_shortname='invenio-rdm',
         click.secho("Use --stop to stop server.", fg="green")
         docker_helper.start_containers()
         time.sleep(60)
+
+
+############
+# POPULATE #
+############
+
+
+@with_appcontext
+def populate_demo_records(docker_helper, verbose):
+    """Add demo records into the instance."""
+    click.secho('Setting up server...', fg='green')
+    cli = create_cli()
+    runner = current_app.test_cli_runner()
+
+    click.secho("Starting containers...", fg="green")
+    docker_helper.start_containers()
+    time.sleep(10)  # Give time to the containers to start properly
+
+    run_command(cli, runner, 'rdm-records demo',
+                message="Populating instance with demo records...",
+                verbose=verbose)
+
+    docker_helper.stop_containers()

--- a/invenio_cli/helpers/scripts.py
+++ b/invenio_cli/helpers/scripts.py
@@ -84,7 +84,7 @@ def _boostrap_prod(base, docker_helper, project_shortname):
 
     click.secho('Building applications docker image...', fg='green')
     # docker build -t my-site:latest .
-    docker_helper.built_image(
+    docker_helper.build_image(
         dockerfile='Dockerfile',
         tag='{project_shortname}:latest'.format(
             project_shortname=project_shortname)

--- a/invenio_cli/helpers/scripts.py
+++ b/invenio_cli/helpers/scripts.py
@@ -210,7 +210,7 @@ def _setup_dev(force, cli, runner, verbose, loglevel, logfile):
 
     run_command(cli, runner, 'db init create',
                 message="Creating database...", verbose=verbose)
-    run_command(cli, runner, 'index init --force',
+    run_command(cli, runner, 'index init',
                 message="Creating indexes...", verbose=verbose)
     run_command(cli, runner, "files location --default 'default-location' " +
                 "{})".format(_get_instance_path(loglevel, logfile)),
@@ -246,7 +246,7 @@ def _setup_prod(force, docker_helper, project_shortname):
         project_shortname, 'invenio db init create',)
     click.secho("Creating indexes...", fg="green")
     docker_helper.execute_cli_command(
-        project_shortname, 'invenio index init --force')
+        project_shortname, 'invenio index init')
     click.secho("Creating files location...", fg="green")
     docker_helper.execute_cli_command(
         project_shortname,

--- a/invenio_cli/helpers/scripts.py
+++ b/invenio_cli/helpers/scripts.py
@@ -213,7 +213,7 @@ def _setup_dev(force, cli, runner, verbose, loglevel, logfile):
     run_command(cli, runner, 'index init',
                 message="Creating indexes...", verbose=verbose)
     run_command(cli, runner, "files location --default 'default-location' " +
-                "{})".format(_get_instance_path(loglevel, logfile)),
+                "{}".format(_get_instance_path(loglevel, logfile)),
                 message="Creating files location...", verbose=verbose)
     run_command(cli, runner, 'roles create admin',
                 message="Creating admin role...", verbose=verbose)
@@ -222,7 +222,7 @@ def _setup_dev(force, cli, runner, verbose, loglevel, logfile):
                 verbose=verbose)
 
 
-def _setup_prod(force, docker_helper, project_shortname):
+def _setup_prod(force, docker_helper, project_shortname, loglevel, logfile):
     # Clean things up
     if force:
         click.secho("Flushing redis cache...", fg="green")
@@ -250,7 +250,8 @@ def _setup_prod(force, docker_helper, project_shortname):
     click.secho("Creating files location...", fg="green")
     docker_helper.execute_cli_command(
         project_shortname,
-        "invenio files location --default 'default-location'")
+        "invenio files location --default 'default-location' " +
+        "{}".format(_get_instance_path(loglevel, logfile)))
     click.secho("Creating admin role...", fg="green")
     docker_helper.execute_cli_command(
         project_shortname, 'invenio roles create admin')

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ setup(
             'server = invenio_cli.cli:server',
             'destroy = invenio_cli.cli:destroy',
             'update = invenio_cli.cli:update',
-            'upgrade = invenio_cli.cli:upgrade'
+            'upgrade = invenio_cli.cli:upgrade',
+            'demo = invenio_cli.cli:demo'
         ],
         'invenio_base.apps': [
             'invenio_cli = invenio_cli:InvenioCli',


### PR DESCRIPTION
Changes:

* Executes setup commands inside the web_api container for `prod` version.
* Differences between docker-compose lower and greater than 1.21 (special characters accepatance).
* Adds command for data population (WIP in prod version)