### PR TITLE
global: refactor logging attributes

### DIFF
--- a/invenio_cli/helpers/__init__.py
+++ b/invenio_cli/helpers/__init__.py
@@ -12,6 +12,6 @@
 from .cookicutter_config import CookiecutterConfig
 from .docker_helper import DockerHelper
 from .filesystem import get_created_files
-from .log import LogPipe
+from .log import LoggingConfig, LogPipe
 from .scripts import bootstrap, populate_demo_records, server, setup, \
     update_statics

--- a/invenio_cli/helpers/log.py
+++ b/invenio_cli/helpers/log.py
@@ -20,10 +20,10 @@ class LogPipe(threading.Thread):
     Based on https://codereview.stackexchange.com/questions/6567
     """
 
-    def __init__(self, filename):
+    def __init__(self, log_config):
         """Setup the object with a logger and start the thread."""
         # Set as INFO to allow all logs to be sent
-        logging.basicConfig(filename=filename, level=logging.INFO)
+        logging.basicConfig(filename=log_config.logfile, level=logging.INFO)
         threading.Thread.__init__(self)
         self.daemon = False
         self.fdRead, self.fdWrite = os.pipe()
@@ -44,3 +44,13 @@ class LogPipe(threading.Thread):
     def close(self):
         """Close the write end of the pipe."""
         os.close(self.fdWrite)
+
+
+class LoggingConfig(object):
+    """Class to encapsulate the logging configuration."""
+
+    def __init__(self, logfile='invenio-cli.log', verbose=False):
+        """Constructor for the LoggingConfig helper."""
+        super(LoggingConfig, self).__init__()
+        self.logfile = logfile
+        self.verbose = verbose

--- a/invenio_cli/helpers/log.py
+++ b/invenio_cli/helpers/log.py
@@ -20,12 +20,12 @@ class LogPipe(threading.Thread):
     Based on https://codereview.stackexchange.com/questions/6567
     """
 
-    def __init__(self, level, filename):
-        """Setup the object with a logger and a level and start the thread."""
+    def __init__(self, filename):
+        """Setup the object with a logger and start the thread."""
+        # Set as INFO to allow all logs to be sent
         logging.basicConfig(filename=filename, level=logging.INFO)
         threading.Thread.__init__(self)
         self.daemon = False
-        self.level = level
         self.fdRead, self.fdWrite = os.pipe()
         self.pipeReader = os.fdopen(self.fdRead)
         self.start()


### PR DESCRIPTION
Changes:

* Remove unused loglevel attribute accross the whole code.
* Set default loggers to level `INFO` and handle the level by checking opperation status code when possible.
* Opened issue to try to handle the level in a better way for output piped from `stdout` and `stderr`. https://github.com/inveniosoftware/invenio-cli/issues/48 Moved to January board, not priority.
* Encapsulated `verbose` and `logfile` into attribute `logging_conf`.

Closes https://github.com/inveniosoftware/invenio-cli/issues/47