### PR TITLE
command: add assets command to build statics and/or assets independently

### DIFF
--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -19,7 +19,8 @@ from cookiecutter.exceptions import OutputDirExistsException
 from cookiecutter.main import cookiecutter
 
 from .helpers import CookiecutterConfig, DockerHelper, LoggingConfig, \
-    LogPipe, bootstrap, get_created_files, populate_demo_records
+    LogPipe, bootstrap, build_assets, get_created_files, \
+    populate_demo_records
 from .helpers import server as scripts_server
 from .helpers import setup as scripts_setup
 from .helpers import update_statics
@@ -169,6 +170,26 @@ def build(base, pre, dev, lock, verbose):
                 .format(mode='development' if dev else 'semi-production'),
                 fg='green')
     docker_helper.create_images()
+
+
+@cli.command()
+@click.option('--dev/--prod', default=True, is_flag=True,
+              help='Which environment to build, it defaults to development')
+@click.option('--statics/--skip-statics', default=True, is_flag=True,
+              help='Regenerate static files or skip this step.')
+@click.option('--webpack/--skip-webpack', default=True, is_flag=True,
+              help='Build the application using webpack or skip this step.')
+@click.option('--verbose', default=False, is_flag=True, required=False,
+              help='Verbose mode will show all logs in the console.')
+def assets(dev, statics, webpack, verbose):
+    """Locks the dependencies and builds the corresponding docker images."""
+    # Create config object
+    invenio_cli = InvenioCli(verbose=verbose)
+
+    click.secho('Generating assets...'.format(
+                flavour=invenio_cli.flavour), fg='green')
+
+    build_assets(dev, statics, webpack, invenio_cli.log_config)
 
 
 def _lock_dependencies(log_config, pre):

--- a/invenio_cli/helpers/__init__.py
+++ b/invenio_cli/helpers/__init__.py
@@ -13,5 +13,5 @@ from .cookicutter_config import CookiecutterConfig
 from .docker_helper import DockerHelper
 from .filesystem import get_created_files
 from .log import LoggingConfig, LogPipe
-from .scripts import bootstrap, populate_demo_records, server, setup, \
-    update_statics
+from .scripts import bootstrap, build_assets, populate_demo_records, server, \
+    setup, update_statics

--- a/invenio_cli/helpers/scripts.py
+++ b/invenio_cli/helpers/scripts.py
@@ -62,7 +62,7 @@ def _bootstrap_dev(pre, log_config):
     logpipe.close()
 
     # Build assets
-    build_assets(log_config)
+    _build_local_assets(log_config)
 
     # Update static files
     update_statics(True, log_config)
@@ -101,17 +101,34 @@ def bootstrap(log_config, dev=True, pre=True,
 
 
 @with_appcontext
-def build_assets(log_config):
-    """Build assets."""
+def _build_local_assets(log_config, statics=True, webpack=True):
+    """Build assets in the containers."""
     cli = create_cli()
     runner = current_app.test_cli_runner()
-    # Collect
-    run_command(cli, runner, "collect -v", message="Collecting assets...",
-                verbose=log_config.verbose)
+    if statics:
+        # Collect
+        run_command(cli, runner, "collect -v", message="Collecting assets...",
+                    verbose=log_config.verbose)
+    if webpack:
+        # Build using webpack
+        run_command(cli, runner, "webpack buildall",
+                    message="Building assets...", verbose=log_config.verbose)
 
-    # Build using webpack
-    run_command(cli, runner, "webpack buildall",
-                message="Building assets...", verbose=log_config.verbose)
+
+def _build_container_assets(log_config, statics=True, webpack=True):
+    """Build assets in the containers."""
+    # TODO: Check how to address this. Requires uwsgi restart.
+    click.secho("Command not supported: In order to rebuild assets in the " +
+                "containers environment, use the `build` command.", fg="red")
+    pass
+
+
+def build_assets(dev, statics, webpack, log_config):
+    """Build assets in the containers."""
+    if dev:
+        _build_local_assets(log_config, statics, webpack)
+    else:
+        _build_container_assets(log_config, statics, webpack)
 
 
 def _force_symlink(file1, file2):

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'flask.commands': [
             'init = invenio_cli.cli:init',
             'build = invenio_cli.cli:build',
+            'assets = invenio_cli.cli:assets',
             'setup = invenio_cli.cli:setup',
             'server = invenio_cli.cli:server',
             'destroy = invenio_cli.cli:destroy',


### PR DESCRIPTION
Changes:
- Adds an `assets` command.
- Allows collecting statics
- Allows building with webpack
- Allows both of the previous actions at the same time.

Caveats:
- The `webpack buidlall` part displays the full logs on the terminal. It is due to some internal part of it printing to stdout and now allowing control. It will be most likely be fixed by https://github.com/pallets/click/issues/737 and/or when we manage to fix https://github.com/inveniosoftware/invenio-cli/issues/66 using an interpreter.
- Not implemented for `--prod`. Since it requires a restart of uwsgi. I assume the workflow for this would be to `update` statics and rebuild the app container (not base) if not. All after having tested/modified in a `--dev` environment. (No ?)

Closes https://github.com/inveniosoftware/invenio-cli/issues/24