### PR TITLE
setup/populate: stop containers only when specified

### DIFF
--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -210,9 +210,11 @@ def _lock_dependencies(log_config, pre):
               help='Which environment to build, it defaults to local')
 @click.option('--force', default=False, is_flag=True,
               help='Delete all content from the database, ES indexes, queues')
+@click.option('--stop-containers', default=False, is_flag=True, required=False,
+              help='Stop containers when finishing the setup operations.')
 @click.option('--verbose', default=False, is_flag=True, required=False,
               help='Verbose mode will show all logs in the console.')
-def setup(local, force, verbose):
+def setup(local, force, stop_containers, verbose):
     """Sets up the application for the first time (DB, ES, queue, etc.)."""
     # Create config object
     invenio_cli = InvenioCli(verbose=verbose)
@@ -224,7 +226,7 @@ def setup(local, force, verbose):
     docker_helper = DockerHelper(local=local,
                                  log_config=invenio_cli.log_config)
 
-    scripts_setup(local=local, force=force,
+    scripts_setup(local=local, force=force, stop_containers=stop_containers,
                   docker_helper=docker_helper,
                   project_shortname=invenio_cli.project_shortname,
                   log_config=invenio_cli.log_config)
@@ -309,13 +311,15 @@ def upgrade(verbose):
 @cli.command()
 @click.option('--local/--containers', default=True, is_flag=True,
               help='Which environment to build, it defaults to local')
+@click.option('--stop-containers', default=False, is_flag=True, required=False,
+              help='Stop containers when finishing the setup operations.')
 @click.option('--verbose', default=False, is_flag=True, required=False,
               help='Verbose mode will show all logs in the console.')
-def demo(local, verbose):
+def demo(local, stop_containers, verbose):
     """Populates instance with demo records."""
     # Create config object
     invenio_cli = InvenioCli(verbose=verbose)
     docker_compose = DockerHelper(local=local,
                                   log_config=invenio_cli.log_config)
     populate_demo_records(local, docker_compose, invenio_cli.project_shortname,
-                          invenio_cli.log_config)
+                          invenio_cli.log_config, stop_containers)

--- a/invenio_cli/helpers/scripts.py
+++ b/invenio_cli/helpers/scripts.py
@@ -285,8 +285,8 @@ def _setup_containers(force, docker_helper, project_shortname, log_config):
 
 
 @with_appcontext
-def setup(log_config, local=True, force=False, docker_helper=None,
-          project_shortname='invenio-rdm'):
+def setup(log_config, local=True, force=False, stop_containers=False,
+          docker_helper=None, project_shortname='invenio-rdm'):
     """Bootstrap server."""
     click.secho('Setting up server...', fg='green')
 
@@ -301,9 +301,10 @@ def setup(log_config, local=True, force=False, docker_helper=None,
     else:
         _setup_containers(force, docker_helper, project_shortname, log_config)
 
-    click.secho("Stopping containers...", fg="green")
-    docker_helper.stop_containers()
-    time.sleep(30)
+    if stop_containers:
+        click.secho("Stopping containers...", fg="green")
+        docker_helper.stop_containers()
+        time.sleep(30)
 
 
 ##########
@@ -370,7 +371,8 @@ def server(log_config, local=True, docker_helper=None,
 
 
 @with_appcontext
-def populate_demo_records(local, docker_helper, project_shortname, log_config):
+def populate_demo_records(local, docker_helper, project_shortname, log_config,
+                          stop_containers=False):
     """Add demo records into the instance."""
     click.secho('Setting up server...', fg='green')
     cli = create_cli()
@@ -389,5 +391,6 @@ def populate_demo_records(local, docker_helper, project_shortname, log_config):
         docker_helper.execute_cli_command(project_shortname,
                                           'invenio rdm-records demo')
 
-    docker_helper.stop_containers()
-    time.sleep(30)
+    if stop_containers:
+        docker_helper.stop_containers()
+        time.sleep(30)


### PR DESCRIPTION
Changes:

- Adds `--stop-containers` to setup and demo commands
- Conditions the stop of the containers to the previous flag being passed. Defaults to false (no stop).

Closes https://github.com/inveniosoftware/invenio-cli/issues/68