### PR TITLE
dependencies: bump cookiecutter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'cookiecutter>=1.6.0,<1.7.0',
+    'cookiecutter>=1.7.0,<1.8.0',
     'click>=7.0,<7.1',
     'docker>=4.1.0,<4.2.0',
     'Flask-BabelEx>=0.9.3',


### PR DESCRIPTION
Why? The CLI is crashing in local mode due to a old/ancient dependency on cookiecutter in `invenio-base` (see https://github.com/inveniosoftware/invenio-base/pull/146). It sets no upper limit, while `invenio-cli` requires `<1.7.0`.

Invenio CLI is installed correctly, however after `build --local` cookiecutter gets installed with a higher version (1.7.0) that collides with the *setup.py* of `invenio-cli` and therefore no other command works.

Note: This might only happen if you install both `invenio-cli` and the local instance in **the same venv**, which is the case in some cases.

I have checked [cookiecutter release history](https://cookiecutter.readthedocs.io/en/1.7.0/HISTORY.html) and it does not seem to be any issues affecting us.

Retrospective: We should really standarize how to install / what we support :) 

Closes: https://github.com/inveniosoftware/invenio-cli/issues/80