### PR TITLE
init + build --local refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
   - REQUIREMENTS=devel
 
 python:
-  - "3.5"
   - "3.6"
 
 before_install:

--- a/invenio_cli/helpers/__init__.py
+++ b/invenio_cli/helpers/__init__.py
@@ -9,7 +9,7 @@
 
 """Invenio CLI helpers module."""
 
-from .cookicutter_config import CookiecutterConfig
+from .cookiecutter_wrapper import CookiecutterWrapper
 from .docker_helper import DockerHelper
 from .filesystem import get_created_files
 from .log import LoggingConfig, LogPipe

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -62,6 +62,10 @@ class CLIConfig(object):
         # Internal to Invenio-cli section
         config_parser[cls.CLI_SECTION] = {}
         config_parser[cls.CLI_SECTION]['flavour'] = flavour
+        # TODO: remove when references to it are removed
+        config_parser[cls.CLI_SECTION]['project_shortname'] = (
+            replay[cls.COOKIECUTTER_SECTION].get('project_shortname', '')
+        )
         config_parser[cls.CLI_SECTION]['project_dir'] = project_dir
         config_parser[cls.CLI_SECTION]['instance_path'] = ''
         config_parser[cls.CLI_SECTION]['logfile'] = \

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio-cli configuration file."""
+
+import os
+from configparser import ConfigParser
+from pathlib import Path
+
+from .filesystem import get_created_files
+
+
+class InvenioCLIConfig(object):
+    """Invenio-cli configuration."""
+
+    CONFIG_FILENAME = '.invenio'
+    CLI_SECTION = 'cli'
+    CLI_PROJECT_NAME = 'project_shortname'
+    CLI_FLAVOUR = 'flavour'
+    CLI_LOGFILE = 'logfile'
+    COOKIECUTTER_SECTION = 'cookiecutter'
+    FILES_SECTION = 'files'
+
+    def __init__(self, flavour=None, verbose=False):
+        """Initialize builder.
+
+        :param flavour: Flavour name.
+        """
+        self.flavour = None
+        self.project_shortname = None
+        self.log_config = None
+        self.config = ConfigParser()
+        self.config.read(CONFIG_FILENAME)
+
+        # There is a .invenio config file
+        if os.path.isfile(CONFIG_FILENAME):
+            try:
+                self.flavour = self.config[CLI_SECTION][CLI_FLAVOUR]
+                self.project_shortname = \
+                    self.config[CLI_SECTION][CLI_PROJECT_NAME]
+                self.log_config = LoggingConfig(
+                    logfile=self.config[CLI_SECTION][CLI_LOGFILE],
+                    verbose=verbose
+                )
+            except KeyError:
+                logging.error(
+                    '{0}, {1} or {2} not configured in CLI section'.format(
+                        CLI_PROJECT_NAME, CLI_LOGFILE, CLI_FLAVOUR
+                    ))
+                exit(1)
+        elif flavour:
+            # There is no .invenio file but the flavour was provided via CLI
+            self.flavour = flavour
+        else:
+            # No value for flavour in .invenio nor CLI
+            logging.error('No flavour specified.')
+            exit(1)
+
+    def read(self, fullpath):
+        """Read invenio-cli config file."""
+        pass
+
+    @classmethod
+    def write(cls, project_dir, flavour, replay):
+        """Write invenio-cli config file.
+
+        :param project_dir: Folder to write the config file into
+        :param replay: dict of cookiecutter replay
+        """
+        config_parser = ConfigParser()
+
+        # CLI parameters section
+        config_parser[cls.CLI_SECTION] = {}
+        config_parser[cls.CLI_SECTION]['flavour'] = flavour
+        # config_parser[cls.CLI_SECTION]['project_shortname'] = \
+        #     os.path.basename(project_dir)
+        config_parser[cls.CLI_SECTION]['logfile'] = \
+            '{path}/logs/invenio-cli.log'.format(path=project_dir)
+
+        # Cookiecutter user input section
+        config_parser[cls.COOKIECUTTER_SECTION] = {}
+        for key, value in replay[cls.COOKIECUTTER_SECTION].items():
+            config_parser[cls.COOKIECUTTER_SECTION][key] = value
+
+        # Generated files section
+        config_parser[cls.FILES_SECTION] = get_created_files(project_dir)
+
+        fullpath = Path(project_dir) / cls.CONFIG_FILENAME
+        with open(fullpath, 'w') as configfile:
+            config_parser.write(configfile)
+
+        return fullpath

--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Local and Containerized Commands."""
+
+import subprocess
+from distutils import dir_util
+
+import click
+
+from . import filesystem
+
+
+class Commands(object):
+    """Abstraction over CLI commands that are either local or containerized."""
+
+    def __init__(self, cli_config, local):
+        """Constructor.
+
+        :param cli_config: :class:CLIConfig instance
+        :param local: boolean True if local environment
+        """
+        if local:
+            self.environment = LocalCommands(cli_config)
+        else:
+            self.environment = ContainerizedCommands()
+
+    def build(self, pre, lock):
+        """Delegates to build of environment commands."""
+        return self.environment.build(pre, lock)
+
+
+class LocalCommands(object):
+    """Local environment CLI commands."""
+
+    def __init__(self, cli_config):
+        """Constructor."""
+        self.cli_config = cli_config
+
+    def _install_py_dependencies(self, pre, lock):
+        """Install Python dependencies."""
+        click.secho('Installing python dependencies...', fg='green')
+        command = ['pipenv', 'install', '--dev']
+        if pre:
+            command += ['--pre']
+        if not lock:
+            command += ['--skip-lock']
+        subprocess.run(command)
+
+    def _update_instance_path(self):
+        """Update path to instance in config."""
+        path = subprocess.run(
+            ['pipenv', 'run', 'invenio', 'shell', '--no-term-title',
+                '-c', '"print(app.instance_path, end=\'\')"'],
+            check=True, universal_newlines=True, stdout=subprocess.PIPE
+        ).stdout.strip()
+        self.cli_config.update_instance_path(path)
+
+    def _symlink_project_config(self):
+        project_config = 'invenio.cfg'
+        click.secho("Symlinking {}...".format(project_config), fg="green")
+        target_path = self.cli_config.get_project_dir() / project_config
+        link_path = self.cli_config.get_instance_path() / project_config
+        filesystem.force_symlink(target_path, link_path)
+
+    def _symlink_templates(self):
+        """Symlink the templates folder."""
+        templates = 'templates'
+        click.secho('Symlinking {}/...'.format(templates), fg='green')
+        target_path = self.cli_config.get_project_dir() / templates
+        link_path = self.cli_config.get_instance_path() / templates
+        filesystem.force_symlink(target_path, link_path)
+
+    def _copy_statics_and_assets(self):
+        """Copy project's statics and assets into instance dir."""
+        click.secho('Copying project statics and assets...', fg='green')
+
+        static = 'static'
+        src_dir = self.cli_config.get_project_dir() / static
+        src_dir = str(src_dir)  # copy_tree below doesn't accept Path objects
+        dst_dir = self.cli_config.get_instance_path() / static
+        dst_dir = str(dst_dir)
+        # using it for a different purpose then intended but very useful
+        dir_util.copy_tree(src_dir, dst_dir)
+
+        # TODO: Uncomment when rebased on @zzachero work
+        # assets = 'assets'
+        # src_dir = self.cli_config.get_project_dir() / assets
+        # src_dir = str(src_dir)
+        # dst_dir = self.cli_config.get_instance_path() / assets
+        # dst_dir = str(dst_dir)
+        # dir_util.copy_tree(src_dir, dst_dir)
+
+    def update_statics_and_assets(self, install):
+        """High-level command to update scss/js/images... files."""
+        click.secho('Collecting statics and assets...', fg='green')
+        # Collect into statics/ folder
+        command = ['pipenv', 'run', 'invenio', 'collect', '--verbose']
+        subprocess.run(command)
+        # Collect into assets/ folder
+        command = ['pipenv', 'run', 'invenio', 'webpack', 'create']
+        subprocess.run(command)
+
+        if install:
+            click.secho('Installing js dependencies...', fg='green')
+            # Installs in assets/node_modules/
+            command = ['pipenv', 'run', 'invenio', 'webpack', 'install']
+            subprocess.run(command)
+
+        self._copy_statics_and_assets()
+
+        click.secho('Building assets...', fg='green')
+        command = ['pipenv', 'run', 'invenio', 'webpack', 'build']
+        subprocess.run(command)
+
+    def build(self, pre, lock):
+        """Local build."""
+        self._install_py_dependencies(pre, lock)
+        self._update_instance_path()
+        self._symlink_project_config()
+        self._symlink_templates()
+        self.update_statics_and_assets(install=True)
+
+
+class ContainerizedCommands(object):
+    """Containerized environment CLI commands."""
+
+    def __init__(self):
+        """Constructor."""
+        pass

--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -88,13 +88,12 @@ class LocalCommands(object):
         # using it for a different purpose then intended but very useful
         dir_util.copy_tree(src_dir, dst_dir)
 
-        # TODO: Uncomment when rebased on @zzachero work
-        # assets = 'assets'
-        # src_dir = self.cli_config.get_project_dir() / assets
-        # src_dir = str(src_dir)
-        # dst_dir = self.cli_config.get_instance_path() / assets
-        # dst_dir = str(dst_dir)
-        # dir_util.copy_tree(src_dir, dst_dir)
+        assets = 'assets'
+        src_dir = self.cli_config.get_project_dir() / assets
+        src_dir = str(src_dir)
+        dst_dir = self.cli_config.get_instance_path() / assets
+        dst_dir = str(dst_dir)
+        dir_util.copy_tree(src_dir, dst_dir)
 
     def update_statics_and_assets(self, install):
         """High-level command to update scss/js/images... files."""

--- a/invenio_cli/helpers/cookiecutter_wrapper.py
+++ b/invenio_cli/helpers/cookiecutter_wrapper.py
@@ -45,7 +45,7 @@ class CookiecutterWrapper(object):
                             '{}.git'.format(self.template_name),
                 # set to cookiecutter release version
                 # reset to master in development
-                'checkout': 'v1.0.0a5'
+                'checkout': 'master'
             }
             return repo
 

--- a/invenio_cli/helpers/cookiecutter_wrapper.py
+++ b/invenio_cli/helpers/cookiecutter_wrapper.py
@@ -26,7 +26,7 @@ class CookiecutterWrapper(object):
     def __init__(self, flavour):
         """Constructor."""
         self.tmp_file = None
-        self.template = None
+        self.template_name = None
         self.flavour = flavour
 
     def cookiecutter(self):
@@ -63,11 +63,12 @@ class CookiecutterWrapper(object):
 
         return self.tmp_file.name
 
-    def get_replay(self):
-        """Retrieve dict of user input values."""
-        return replay.load(tempfile.gettempdir(), self.template_name)
-
     def remove_config(self):
         """Remove the tmp file."""
         if self.tmp_file:
             self.tmp_file.close()
+
+    def get_replay(self):
+        """Retrieve dict of user input values."""
+        if self.template_name:
+            return replay.load(tempfile.gettempdir(), self.template_name)

--- a/invenio_cli/helpers/filesystem.py
+++ b/invenio_cli/helpers/filesystem.py
@@ -9,8 +9,9 @@
 
 """Invenio Filesystem helper functions."""
 
+import errno
 import hashlib
-from os import listdir
+import os
 from os.path import isdir
 from pathlib import Path
 
@@ -35,7 +36,7 @@ def hash_file(path_to_file):
 def get_created_files(folder):
     """Return the generated tree of files (and their hash) and folders."""
     files = {}
-    for name in listdir(folder):
+    for name in os.listdir(folder):
         path = Path(folder)  # Current path
 
         # Add files and their hash
@@ -46,3 +47,13 @@ def get_created_files(folder):
             files[name] = get_created_files(path / name)
 
     return files
+
+
+def force_symlink(target, link_name):
+    """Forcefully create symlink at link_name pointing to target."""
+    try:
+        os.symlink(target, link_name)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            os.remove(link_name)
+            os.symlink(target, link_name)

--- a/tests/test_helpers/test_cli_config.py
+++ b/tests/test_helpers/test_cli_config.py
@@ -78,6 +78,11 @@ def test_cli_config_get_project_dir(config_path):
     cli_config = CLIConfig(config_path)
 
     assert cli_config.get_project_dir() == Path(os.path.dirname(config_path))
+    # TODO: remove when unused
+    assert (
+        cli_config.config[CLIConfig.CLI_SECTION]['project_shortname'] ==
+        'my-site'
+    )
 
 
 def test_cli_config_get_instance_path(config_path):

--- a/tests/test_helpers/test_cli_config.py
+++ b/tests/test_helpers/test_cli_config.py
@@ -9,9 +9,12 @@
 """Module config_file tests."""
 import os
 import tempfile
+from configparser import ConfigParser
 from pathlib import Path
 
-from invenio_cli.helpers.cli_config import InvenioCLIConfig
+import pytest
+
+from invenio_cli.helpers.cli_config import CLIConfig
 
 
 def test_cli_config_write():
@@ -38,11 +41,52 @@ def test_cli_config_write():
 
     # No configuration file
     assert not os.path.isfile(
-        Path(project_dir) / InvenioCLIConfig.CONFIG_FILENAME
+        Path(project_dir) / CLIConfig.CONFIG_FILENAME
     )
 
-    config_path = InvenioCLIConfig.write(project_dir, flavour, replay)
+    config_path = CLIConfig.write(project_dir, flavour, replay)
 
     assert os.path.isfile(config_path)
-    # TODO: check content more thoroughly
-    # InvenioCLIConfig.read
+
+
+@pytest.fixture
+def config_path():
+    tmp_dir = tempfile.TemporaryDirectory()
+    project_dir = tmp_dir.name
+    flavour = 'RDM'
+    replay = {
+        'cookiecutter': {
+            'project_name': 'My Site',
+            'project_shortname': 'my-site',
+            'project_site': 'my-site.com',
+            'github_repo': 'my-site/my-site',
+            'description': 'Invenio RDM My Site Instance',
+            'author_name': 'CERN',
+            'author_email': 'info@my-site.com',
+            'year': '2020',
+            'database': 'postgresql',
+            'elasticsearch': '7',
+            '_template': 'https://github.com/inveniosoftware/cookiecutter-invenio-rdm.git'  # noqa
+        }
+    }
+    # Need to yield in order for tmp_dir to not be gc'ed and therefore the
+    # temporary directory deleted
+    yield CLIConfig.write(project_dir, flavour, replay)
+
+
+def test_cli_config_get_project_dir(config_path):
+    cli_config = CLIConfig(config_path)
+
+    assert cli_config.get_project_dir() == Path(os.path.dirname(config_path))
+
+
+def test_cli_config_get_instance_path(config_path):
+    cli_config = CLIConfig(config_path)
+
+    assert cli_config.get_instance_path() == Path('')
+
+    # Update instance path to now see if we retrieve it
+    instance_path = os.path.join(os.path.dirname(config_path), '.venv/')
+    cli_config.update_instance_path(instance_path)
+
+    assert cli_config.get_instance_path() == Path(instance_path)

--- a/tests/test_helpers/test_cli_config.py
+++ b/tests/test_helpers/test_cli_config.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module config_file tests."""
+import os
+import tempfile
+from pathlib import Path
+
+from invenio_cli.helpers.cli_config import InvenioCLIConfig
+
+
+def test_cli_config_write():
+    """Check config file is generated: preliminary superficial test."""
+
+    tmp_dir = tempfile.TemporaryDirectory()
+    project_dir = tmp_dir.name
+    flavour = 'RDM'
+    replay = {
+        'cookiecutter': {
+            'project_name': 'My Site',
+            'project_shortname': 'my-site',
+            'project_site': 'my-site.com',
+            'github_repo': 'my-site/my-site',
+            'description': 'Invenio RDM My Site Instance',
+            'author_name': 'CERN',
+            'author_email': 'info@my-site.com',
+            'year': '2020',
+            'database': 'postgresql',
+            'elasticsearch': '7',
+            '_template': 'https://github.com/inveniosoftware/cookiecutter-invenio-rdm.git'  # noqa
+        }
+    }
+
+    # No configuration file
+    assert not os.path.isfile(
+        Path(project_dir) / InvenioCLIConfig.CONFIG_FILENAME
+    )
+
+    config_path = InvenioCLIConfig.write(project_dir, flavour, replay)
+
+    assert os.path.isfile(config_path)
+    # TODO: check content more thoroughly
+    # InvenioCLIConfig.read

--- a/tests/test_helpers/test_commands.py
+++ b/tests/test_helpers/test_commands.py
@@ -133,10 +133,9 @@ def test_localcommands_uppdate_statics_and_assets(
     patched_dir_util.copy_tree.assert_any_call(
         'project_dir/static', 'instance_dir/static'
     )
-    # TODO: Uncomment when rebased on @zzachero assets work
-    # patched_dir_util.copy_tree.assert_any_call(
-    #     'project_dir/assets', 'instance_dir/assets'
-    # )
+    patched_dir_util.copy_tree.assert_any_call(
+        'project_dir/assets', 'instance_dir/assets'
+    )
 
     # Reset for install=False assertions
     patched_subprocess.run.reset_mock()

--- a/tests/test_helpers/test_commands.py
+++ b/tests/test_helpers/test_commands.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module commands.py's tests."""
+from pathlib import Path
+from unittest.mock import Mock, call, patch
+
+from invenio_cli.helpers.commands import Commands, ContainerizedCommands, \
+    LocalCommands
+
+
+def test_commands_delegates_to_environment():
+    commands = Commands(Mock(), True)
+
+    assert isinstance(commands.environment, LocalCommands)
+
+    commands = Commands(Mock(), False)
+
+    assert isinstance(commands.environment, ContainerizedCommands)
+
+
+@patch('invenio_cli.helpers.commands.subprocess')
+def test_localcommands_build_install_py_dependencies(patched_subprocess):
+    commands = LocalCommands(Mock())
+
+    commands._install_py_dependencies(pre=True, lock=True)
+
+    patched_subprocess.run.assert_any_call(
+        ['pipenv', 'install', '--dev', '--pre'])
+
+    commands._install_py_dependencies(pre=True, lock=False)
+
+    patched_subprocess.run.assert_any_call(
+        ['pipenv', 'install', '--dev', '--pre', '--skip-lock'])
+
+    commands._install_py_dependencies(pre=False, lock=True)
+
+    patched_subprocess.run.assert_any_call(
+        ['pipenv', 'install', '--dev'])
+
+    commands._install_py_dependencies(pre=False, lock=False)
+
+    patched_subprocess.run.assert_any_call(
+        ['pipenv', 'install', '--dev', '--skip-lock'])
+
+
+@patch('invenio_cli.helpers.commands.subprocess')
+def test_localcommands_update_instance_path(patched_subprocess):
+    cli_config = Mock()
+    patched_subprocess.run.return_value = Mock(stdout='instance_dir')
+    commands = LocalCommands(cli_config)
+
+    commands._update_instance_path()
+
+    patched_subprocess.run.assert_called_with(
+        ['pipenv', 'run', 'invenio', 'shell', '--no-term-title',
+            '-c', '"print(app.instance_path, end=\'\')"'],
+        check=True, universal_newlines=True, stdout=patched_subprocess.PIPE
+    )
+    cli_config.update_instance_path.assert_called_with('instance_dir')
+
+
+@patch('invenio_cli.helpers.filesystem.os')
+def test_localcommands_symlink_project_config(patched_os):
+    class FakeCLIConfig(object):
+        def __init__(self):
+            pass
+
+        def get_project_dir(self):
+            return Path('project_dir')
+
+        def get_instance_path(self):
+            return Path('instance_dir')
+
+    commands = LocalCommands(FakeCLIConfig())
+
+    commands._symlink_project_config()
+
+    patched_os.symlink.assert_called_with(
+        Path('project_dir/invenio.cfg'), Path('instance_dir/invenio.cfg'))
+
+
+@patch('invenio_cli.helpers.filesystem.os')
+def test_localcommands_symlink_templates(patched_os):
+    class FakeCLIConfig(object):
+        def __init__(self):
+            pass
+
+        def get_project_dir(self):
+            return Path('project_dir')
+
+        def get_instance_path(self):
+            return Path('instance_dir')
+
+    commands = LocalCommands(FakeCLIConfig())
+
+    commands._symlink_templates()
+
+    patched_os.symlink.assert_called_with(
+        Path('project_dir/templates'), Path('instance_dir/templates'))
+
+
+@patch('invenio_cli.helpers.commands.dir_util')
+@patch('invenio_cli.helpers.commands.subprocess')
+def test_localcommands_uppdate_statics_and_assets(
+        patched_subprocess, patched_dir_util):
+    class FakeCLIConfig(object):
+        def __init__(self):
+            pass
+
+        def get_project_dir(self):
+            return Path('project_dir')
+
+        def get_instance_path(self):
+            return Path('instance_dir')
+
+    commands = LocalCommands(FakeCLIConfig())
+
+    commands.update_statics_and_assets(install=True)
+
+    expected_calls = [
+        call(['pipenv', 'run', 'invenio', 'collect', '--verbose']),
+        call(['pipenv', 'run', 'invenio', 'webpack', 'create']),
+        call(['pipenv', 'run', 'invenio', 'webpack', 'install']),
+        call(['pipenv', 'run', 'invenio', 'webpack', 'build']),
+    ]
+    assert patched_subprocess.run.mock_calls == expected_calls
+    patched_dir_util.copy_tree.assert_any_call(
+        'project_dir/static', 'instance_dir/static'
+    )
+    # TODO: Uncomment when rebased on @zzachero assets work
+    # patched_dir_util.copy_tree.assert_any_call(
+    #     'project_dir/assets', 'instance_dir/assets'
+    # )
+
+    # Reset for install=False assertions
+    patched_subprocess.run.reset_mock()
+
+    commands.update_statics_and_assets(install=False)
+
+    expected_calls = [
+        call(['pipenv', 'run', 'invenio', 'collect', '--verbose']),
+        call(['pipenv', 'run', 'invenio', 'webpack', 'create']),
+        call(['pipenv', 'run', 'invenio', 'webpack', 'build'])
+    ]
+    assert patched_subprocess.run.mock_calls == expected_calls


### PR DESCRIPTION
This is the first step in refactoring the cli:

- Only deals with init and build --local for now
- Illustrates relatively well how I will proceed with the rest of the commands: feedback now would be greatly appreciated to help orient things
- Removed the verbose flag for now to keep things a little more scoped. I do not mind at all adding it back later. 
- It adds tests: I decided to principally go the mocking way (there is temporary file creation for the cli config file only). I am experimenting here, if you've had prior experience testing similar things and have found productive approaches let me know. Good thing: tests are fast and cover a lot of things. Bad thing: confidence level is not as high given that some mocked calls expect specific input / return specific output in reality and that can only be known by running them for real. Closes #41 (the full refactor will)
- Sets #72 to be closed easily when working on update command: broken up buildall into create, install, build with `install` optional.
- Fixes #83 (at least for build --local , but will for rest)
- Note: this https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/38 needs to be merged
- Will remove former code once all commands are dealt with
- It isn't rebased on @zzachero's work, but will be when that work is merged. 
- Wrapping cookiecutter in that CookiecutterWrapper will make #100 easier to address too... (I think)

I think that's all :D
     