### PR TITLE
services: start+configure containers (--local)

### DIFF
--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -125,29 +125,25 @@ def build(pre, local, lock):
     """
     cli_config = CLIConfig()
     commands = Commands(cli_config, local)
-    commands.build(pre, lock)
+    commands.build(pre=pre, lock=lock)
 
 
 @cli.command()
 @click.option('--local/--containers', default=True, is_flag=True,
               help='Which environment to build, it defaults to local')
-@click.option('--statics/--skip-statics', default=True, is_flag=True,
-              help='Regenerate static files or skip this step.')
-@click.option('--webpack/--skip-webpack', default=True, is_flag=True,
-              help='Build the application using webpack or skip this step.')
-@click.option('--verbose', default=False, is_flag=True, required=False,
-              help='Verbose mode will show all logs in the console.')
-def assets(local, statics, webpack, verbose):
-    """Locks the dependencies and builds the corresponding docker images."""
-    # Create config object
-    invenio_cli = InvenioCli(verbose=verbose)
+@click.option('--force', default=False, is_flag=True,
+              help='Force recreation of db tables, ES indices, queues...')
+def services(local, force):
+    """Starts services and ensures they are setup (DB, ES, queue, etc.).
 
-    click.secho('Generating assets...'.format(
-                flavour=invenio_cli.flavour), fg='green')
-
-    build_assets(local, statics, webpack, invenio_cli.log_config)
+    TODO: Forward any extra argument to docker-compose.
+    """
+    cli_config = CLIConfig()
+    commands = Commands(cli_config, local)
+    commands.services(force=force)
 
 
+# TODO: Remove when --containers implemented in the above
 @cli.command()
 @click.option('--local/--containers', default=True, is_flag=True,
               help='Which environment to build, it defaults to local')
@@ -173,6 +169,26 @@ def setup(local, force, stop_containers, verbose):
                   docker_helper=docker_helper,
                   project_shortname=invenio_cli.project_shortname,
                   log_config=invenio_cli.log_config)
+
+
+@cli.command()
+@click.option('--local/--containers', default=True, is_flag=True,
+              help='Which environment to build, it defaults to local')
+@click.option('--statics/--skip-statics', default=True, is_flag=True,
+              help='Regenerate static files or skip this step.')
+@click.option('--webpack/--skip-webpack', default=True, is_flag=True,
+              help='Build the application using webpack or skip this step.')
+@click.option('--verbose', default=False, is_flag=True, required=False,
+              help='Verbose mode will show all logs in the console.')
+def assets(local, statics, webpack, verbose):
+    """Locks the dependencies and builds the corresponding docker images."""
+    # Create config object
+    invenio_cli = InvenioCli(verbose=verbose)
+
+    click.secho('Generating assets...'.format(
+                flavour=invenio_cli.flavour), fg='green')
+
+    build_assets(local, statics, webpack, invenio_cli.log_config)
 
 
 @cli.command()

--- a/setup.py
+++ b/setup.py
@@ -83,8 +83,9 @@ setup(
         'flask.commands': [
             'init = invenio_cli.cli:init',
             'build = invenio_cli.cli:build',
+            'services = invenio_cli.cli:services',
+            'setup = invenio_cli.cli:setup',  # TODO: remove when transitioned
             'assets = invenio_cli.cli:assets',
-            'setup = invenio_cli.cli:setup',
             'server = invenio_cli.cli:server',
             'destroy = invenio_cli.cli:destroy',
             'update = invenio_cli.cli:update',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ install_requires = [
     'pipenv==2018.11.26',
     'PyYAML>=5.1.2,<5.2.0',
     'redis>=3.3.11,<3.4.0',
+    'Werkzeug>=0.16.1,<1.0.0'
 ]
 
 packages = find_packages()

--- a/tests/test_helpers/test_dockerhelper.py
+++ b/tests/test_helpers/test_dockerhelper.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module docker_helper tests."""
+from unittest.mock import patch
+
+from invenio_cli.helpers.docker_helper import DockerHelper
+
+
+@patch('invenio_cli.helpers.docker_helper.subprocess')
+def test_start_containers(patched_subprocess):
+    docker_helper = DockerHelper(local=True)
+
+    docker_helper.start_containers()
+
+    patched_subprocess.run.assert_called_with(
+        [
+            'docker-compose', '--file', 'docker-compose.yml', 'up', '--build',
+            '--detach'
+        ]
+    )
+
+    docker_helper = DockerHelper(local=False)
+
+    docker_helper.start_containers()
+
+    patched_subprocess.run.assert_called_with(
+        [
+            'docker-compose', '--file', 'docker-compose.full.yml', 'up',
+            '--build', '--detach'
+        ]
+    )


### PR DESCRIPTION
Combines the idea of starting the services with their configuration: there won't be a need to run `invenio-cli setup`