### PR TITLE
containerize: make pre-release deps lock optional

### DIFF
--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -89,11 +89,13 @@ def services(force):
 
 
 @cli.command()
+@click.option('--pre', default=False, is_flag=True,
+              help='If specified, allows the installation of alpha releases')
 @click.option('--force', default=False, is_flag=True,
               help='Force recreation of db tables, ES indices, queues...')
 @click.option('--install-js/--no-install-js', default=True, is_flag=True,
               help="(re-)Install JS dependencies, defaults to True")
-def containerize(force, install_js):
+def containerize(pre, force, install_js):
     """Setup and run all containers (docker-compose.full.yml).
 
     Think of it as a production compilation build + running.
@@ -103,7 +105,7 @@ def containerize(force, install_js):
         cli_config,
         DockerHelper(cli_config.get_project_shortname(), local=False)
     )
-    commands.containerize(force=force, install=install_js)
+    commands.containerize(pre=pre, force=force, install=install_js)
 
 
 @cli.command()

--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -313,15 +313,20 @@ class ContainerizedCommands(object):
         self.docker_helper.execute_cli_command(
             project_shortname, 'invenio webpack build')
 
-    def _lock_python_dependencies(self):
+    def _lock_python_dependencies(self, pre):
         """Creates Pipfile.lock if not existing."""
+        command = ['pipenv', 'lock']
+
+        if pre:
+            command += ['--pre']
+
         locked = 'Pipfile.lock' in os.listdir('.')
         if not locked:
-            subprocess.run(['pipenv', 'lock', '--pre'], check=True)
+            subprocess.run(command, check=True)
 
-    def containerize(self, force, install):
+    def containerize(self, pre, force, install):
         """Launch fully containerized application."""
-        self._lock_python_dependencies()
+        self._lock_python_dependencies(pre)
 
         click.secho('Making sure containers are up...', fg='green')
         self.docker_helper.start_containers()


### PR DESCRIPTION
Changes:
* Adds `pre` to containerize command to allow locking pre-releases only when specified.

Closes https://github.com/inveniosoftware/invenio-cli/issues/114