### PR TITLE
cli: symlink app_data + bump version

### DIFF
--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -70,19 +70,11 @@ class LocalCommands(object):
         ).stdout.strip()
         self.cli_config.update_instance_path(path)
 
-    def _symlink_project_config(self):
-        project_config = 'invenio.cfg'
-        click.secho("Symlinking {}...".format(project_config), fg="green")
-        target_path = self.cli_config.get_project_dir() / project_config
-        link_path = self.cli_config.get_instance_path() / project_config
-        filesystem.force_symlink(target_path, link_path)
-
-    def _symlink_templates(self):
-        """Symlink the templates folder."""
-        templates = 'templates'
-        click.secho('Symlinking {}/...'.format(templates), fg='green')
-        target_path = self.cli_config.get_project_dir() / templates
-        link_path = self.cli_config.get_instance_path() / templates
+    def _symlink_project_file_or_folder(self, target):
+        """Create symlink in instance pointing to project file or folder."""
+        click.secho('Symlinking {}...'.format(target), fg='green')
+        target_path = self.cli_config.get_project_dir() / target
+        link_path = self.cli_config.get_instance_path() / target
         filesystem.force_symlink(target_path, link_path)
 
     def _symlink_assets_templates(self, files_to_link):
@@ -145,8 +137,9 @@ class LocalCommands(object):
         """Local build."""
         self._install_py_dependencies(pre, lock)
         self._update_instance_path()
-        self._symlink_project_config()
-        self._symlink_templates()
+        self._symlink_project_file_or_folder('invenio.cfg')
+        self._symlink_project_file_or_folder('templates')
+        self._symlink_project_file_or_folder('app_data')
         self.update_statics_and_assets(install=True)
 
     def _ensure_containers_running(self):

--- a/invenio_cli/helpers/cookiecutter_wrapper.py
+++ b/invenio_cli/helpers/cookiecutter_wrapper.py
@@ -49,7 +49,7 @@ class CookiecutterWrapper(object):
                 'cookiecutter-invenio-rdm.git'
             )
             self.template_name = self.extract_template_name(self.template)
-            self.checkout = template_checkout[1] or 'v0.6.0'
+            self.checkout = template_checkout[1] or 'v0.7.0'
 
     def cookiecutter(self):
         """Wrap cookiecutter call."""

--- a/invenio_cli/version.py
+++ b/invenio_cli/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_cli.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.10.1'
+__version__ = '0.11.0'

--- a/tests/test_helpers/test_commands.py
+++ b/tests/test_helpers/test_commands.py
@@ -166,6 +166,29 @@ def test_localcommands_update_statics_and_assets(
     assert patched_subprocess.run.mock_calls == expected_calls
 
 
+def test_localcommands_install():
+    commands = LocalCommands(fake_cli_config)
+    commands._install_py_dependencies = Mock()
+    commands._update_instance_path = Mock()
+    commands._symlink_project_file_or_folder = Mock()
+    commands.update_statics_and_assets = Mock()
+
+    commands.install(False, False)
+
+    commands._install_py_dependencies.assert_called_with(False, False)
+    commands._update_instance_path.assert_called()
+    expected_symlink_calls = [
+        call('invenio.cfg'),
+        call('templates'),
+        call('app_data')
+    ]
+    assert (
+        commands._symlink_project_file_or_folder.mock_calls ==
+        expected_symlink_calls
+    )
+    commands.update_statics_and_assets.assert_called_with(install=True)
+
+
 @patch('invenio_cli.helpers.commands.subprocess')
 @patch('invenio_cli.helpers.commands.time')
 @patch('invenio_cli.helpers.commands.DockerHelper')

--- a/tests/test_helpers/test_commands.py
+++ b/tests/test_helpers/test_commands.py
@@ -101,20 +101,18 @@ def fake_cli_config():
 
 
 @patch('invenio_cli.helpers.filesystem.os')
-def test_localcommands_symlink_project_config(patched_os, fake_cli_config):
+def test_symlink_project_file_or_folder(patched_os, fake_cli_config):
     commands = LocalCommands(fake_cli_config)
+    file = 'invenio.cfg'
 
-    commands._symlink_project_config()
+    commands._symlink_project_file_or_folder(file)
 
     patched_os.symlink.assert_called_with(
         Path('project_dir/invenio.cfg'), Path('instance_dir/invenio.cfg'))
 
+    folder = 'templates/'
 
-@patch('invenio_cli.helpers.filesystem.os')
-def test_localcommands_symlink_templates(patched_os, fake_cli_config):
-    commands = LocalCommands(fake_cli_config)
-
-    commands._symlink_templates()
+    commands._symlink_project_file_or_folder(folder)
 
     patched_os.symlink.assert_called_with(
         Path('project_dir/templates'), Path('instance_dir/templates'))

--- a/tests/test_helpers/test_cookiecutter_wrapper.py
+++ b/tests/test_helpers/test_cookiecutter_wrapper.py
@@ -11,6 +11,19 @@
 from invenio_cli.helpers.cookiecutter_wrapper import CookiecutterWrapper
 
 
+def test_constructor():
+    cookiecutter = CookiecutterWrapper('RDM', ('', 'master'))
+
+    assert cookiecutter.tmp_file is None
+    assert cookiecutter.flavour == 'RDM'
+    assert (
+        cookiecutter.template == 'https://github.com/inveniosoftware/'
+                                 'cookiecutter-invenio-rdm.git'
+    )
+    assert cookiecutter.template_name == 'cookiecutter-invenio-rdm'
+    assert cookiecutter.checkout == 'master'
+
+
 def test_extract_template_name_git_url():
     tpl_name = CookiecutterWrapper.extract_template_name(
         'https://github.com/inveniosoftware/cookiecutter-invenio-rdm.git'


### PR DESCRIPTION
Needed for custom vocab to work in development mode.

Also bump the version BUT :warning: this needs the cookiecutter PR https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/59 to be merged first, so that its version can be used.