### PR TITLE
cookiecutter: add jinja filter for slugifying input

### DIFF
--- a/invenio_cli/jinja_extensions/__init__.py
+++ b/invenio_cli/jinja_extensions/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio CLI Jinja2 template filters."""
+
+from .slugify import SlugifyExtension
+
+__all__ = ['SlugifyExtension']

--- a/invenio_cli/jinja_extensions/slugify.py
+++ b/invenio_cli/jinja_extensions/slugify.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+from jinja2.ext import Extension
+from slugify import slugify as pyslugify
+
+class SlugifyExtension(Extension):
+    """Jinja2 Extension to slugify string."""
+
+    def __init__(self, environment):
+        """Jinja2 Extension constructor."""
+        super(SlugifyExtension, self).__init__(environment)
+
+        def slugify(value, **kwargs):
+            """Slugifies the value."""
+            return pyslugify(value, **kwargs)
+
+        environment.filters['slugify'] = slugify

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ install_requires = [
     'docker>=4.1.0,<4.2.0',
     'Flask-BabelEx>=0.9.4',
     'pipenv==2018.11.26',
+    'python-slugify>=4.0.0,<5.0.0',
     'PyYAML>=5.1.2',
 ]
 


### PR DESCRIPTION
Creates a Jinja2 Extension to add the slugify filter. It will then be used in Cookiecutter (by invenio-cli).

**Note**: The code belongs here *for now* since it needs to be installed. I am going to make a PR to cookiecutter since I believe its a case that could happen to more people (https://github.com/cookiecutter/cookiecutter/issues/1333).

Result sample:

```
% cookiecutter ../../cookiecutter-invenio-rdm 
project_name [My Site]: Pablo's version
project_shortname [pablo-s-version]: 
project_site [pablo-s-version.com]: 
github_repo [pablo-s-version/pablo-s-version]: 
description [Invenio RDM Pablo's version Instance]: 
```