### PR TITLE
config: use cwd as project_dir

### DIFF
--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -36,6 +36,10 @@ class CLIConfig(object):
         try:
             with open(fullpath) as cfg_file:
                 self.config.read_file(cfg_file)
+
+            # Assign current dir a project dir. If reached here, it exists.
+            self.project_dir = Path(os.getcwd())
+
         except FileNotFoundError:
             click.secho(
                 "Missing '.invenio' file in current directory. "
@@ -45,7 +49,7 @@ class CLIConfig(object):
 
     def get_project_dir(self):
         """Returns path to project directory."""
-        return Path(self.config[CLIConfig.CLI_SECTION]['project_dir'])
+        return self.project_dir
 
     def get_instance_path(self):
         """Returns path to application instance directory."""
@@ -88,11 +92,9 @@ class CLIConfig(object):
         # Internal to Invenio-cli section
         config_parser[cls.CLI_SECTION] = {}
         config_parser[cls.CLI_SECTION]['flavour'] = flavour
-        config_parser[cls.CLI_SECTION]['project_dir'] = project_dir
         config_parser[cls.CLI_SECTION]['instance_path'] = ''
         config_parser[cls.CLI_SECTION]['services_setup'] = str(False)
-        config_parser[cls.CLI_SECTION]['logfile'] = \
-            '{path}/logs/invenio-cli.log'.format(path=project_dir)
+        config_parser[cls.CLI_SECTION]['logfile'] = '/logs/invenio-cli.log'
 
         # Cookiecutter user input section
         config_parser[cls.COOKIECUTTER_SECTION] = {}

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -18,27 +18,40 @@ from .filesystem import get_created_files
 
 
 class CLIConfig(object):
-    """Invenio-cli configuration."""
+    """Invenio-cli configuration.
+
+    It provides a combined interface to the local CLI configuration which
+    is typically split between a
+        .invenio file with general project configuration
+        .invenio.private with per machine configuration
+                         (not version controlled)
+    """
 
     CONFIG_FILENAME = '.invenio'
+    PRIVATE_CONFIG_FILENAME = '.invenio.private'
     CLI_SECTION = 'cli'
     COOKIECUTTER_SECTION = 'cookiecutter'
     FILES_SECTION = 'files'
 
-    def __init__(self, fullpath=CONFIG_FILENAME, verbose=False):
+    def __init__(self, project_dir='./', verbose=False):
         """Constructor.
 
-        :param flavour: Flavour name.
+        :param config_dir: Path to general cli config file.
+        :param config_path: Absolute path to per machine cli config file.
         """
+        self.config_path = Path(project_dir) / self.CONFIG_FILENAME
         self.config = ConfigParser()
-        self.fullpath = fullpath
+        self.private_config_path = (
+            Path(project_dir) / self.PRIVATE_CONFIG_FILENAME
+        )
+        self.private_config = ConfigParser()
 
         try:
-            with open(fullpath) as cfg_file:
+            with open(self.config_path) as cfg_file:
                 self.config.read_file(cfg_file)
 
-            # Assign current dir a project dir. If reached here, it exists.
-            self.project_dir = Path(os.getcwd())
+            with open(self.private_config_path) as cfg_file:
+                self.private_config.read_file(cfg_file)
 
         except FileNotFoundError:
             click.secho(
@@ -49,30 +62,35 @@ class CLIConfig(object):
 
     def get_project_dir(self):
         """Returns path to project directory."""
-        return self.project_dir
+        return Path(self.private_config[CLIConfig.CLI_SECTION]['project_dir'])
 
     def get_instance_path(self):
         """Returns path to application instance directory."""
-        return Path(self.config[CLIConfig.CLI_SECTION]['instance_path'])
+        return Path(
+            self.private_config[CLIConfig.CLI_SECTION]['instance_path']
+        )
 
     def update_instance_path(self, new_instance_path):
         """Updates path to application instance directory."""
-        self.config[CLIConfig.CLI_SECTION]['instance_path'] = \
+        self.private_config[CLIConfig.CLI_SECTION]['instance_path'] = \
             str(new_instance_path)
 
-        with open(self.fullpath, 'w') as configfile:
-            self.config.write(configfile)
+        with open(self.private_config_path, 'w') as configfile:
+            self.private_config.write(configfile)
 
     def get_services_setup(self):
         """Returns bool whether services have been setup or not."""
-        return self.config.getboolean(CLIConfig.CLI_SECTION, 'services_setup')
+        return self.private_config.getboolean(
+            CLIConfig.CLI_SECTION, 'services_setup'
+        )
 
     def update_services_setup(self, is_setup):
         """Updates path to application instance directory."""
-        self.config[CLIConfig.CLI_SECTION]['services_setup'] = str(is_setup)
+        self.private_config[CLIConfig.CLI_SECTION]['services_setup'] = \
+            str(is_setup)
 
-        with open(self.fullpath, 'w') as configfile:
-            self.config.write(configfile)
+        with open(self.private_config_path, 'w') as configfile:
+            self.private_config.write(configfile)
 
     def get_project_shortname(self):
         """Returns the project's shortname."""
@@ -85,15 +103,15 @@ class CLIConfig(object):
         :param project_dir: Folder to write the config file into
         :param flavour: 'RDM' or 'ILS'
         :param replay: dict of cookiecutter replay
-        :return: full path to config file
+        :return: absolute Path to config (project) directory
         """
         config_parser = ConfigParser()
+        # Convert to absolute Path because simpler to reason about and pass
+        project_dir = Path(project_dir).resolve()
 
         # Internal to Invenio-cli section
         config_parser[cls.CLI_SECTION] = {}
         config_parser[cls.CLI_SECTION]['flavour'] = flavour
-        config_parser[cls.CLI_SECTION]['instance_path'] = ''
-        config_parser[cls.CLI_SECTION]['services_setup'] = str(False)
         config_parser[cls.CLI_SECTION]['logfile'] = '/logs/invenio-cli.log'
 
         # Cookiecutter user input section
@@ -104,8 +122,18 @@ class CLIConfig(object):
         # Generated files section
         config_parser[cls.FILES_SECTION] = get_created_files(project_dir)
 
-        fullpath = Path(project_dir) / cls.CONFIG_FILENAME
-        with open(fullpath, 'w') as configfile:
+        config_path = project_dir / cls.CONFIG_FILENAME
+        with open(config_path, 'w') as configfile:
             config_parser.write(configfile)
 
-        return fullpath
+        # Internal to machine (not version controlled)
+        config_parser = ConfigParser()
+        config_parser[cls.CLI_SECTION] = {}
+        config_parser[cls.CLI_SECTION]['project_dir'] = str(project_dir)
+        config_parser[cls.CLI_SECTION]['instance_path'] = ''
+        config_parser[cls.CLI_SECTION]['services_setup'] = str(False)
+        private_config_path = project_dir / cls.PRIVATE_CONFIG_FILENAME
+        with open(private_config_path, 'w') as configfile:
+            config_parser.write(configfile)
+
+        return project_dir

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_requires = [
 
 install_requires = [
     'cookiecutter>=1.7.0,<1.8.0',
-    'click>=7.0,<7.1',
+    'click>=7.0,<8.0',
     'docker>=4.1.0,<4.2.0',
     'Flask-BabelEx>=0.9.4',
     'pipenv==2018.11.26',

--- a/tests/test_helpers/test_cli_config.py
+++ b/tests/test_helpers/test_cli_config.py
@@ -89,7 +89,7 @@ def test_cli_config_config_file_not_found(patched_exit, config_path):
 def test_cli_config_get_project_dir(config_path):
     cli_config = CLIConfig(config_path)
 
-    assert cli_config.get_project_dir() == Path(os.path.dirname(config_path))
+    assert cli_config.get_project_dir() == Path(os.getcwd())
 
 
 def test_cli_config_instance_path(config_path):

--- a/tests/test_helpers/test_filesystem.py
+++ b/tests/test_helpers/test_filesystem.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module docker_helper tests."""
+import tempfile
+from pathlib import Path
+
+from invenio_cli.helpers.filesystem import get_created_files
+
+
+def test_get_created_files():
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_dir_path = Path(tmp_dir.name)
+    (tmp_dir_path / 'foo').touch()
+    (tmp_dir_path / 'bar').mkdir()
+    (tmp_dir_path / 'bar' / 'baz').touch()
+
+    files_tree = get_created_files(tmp_dir.name)
+
+    expected_files_tree = {
+        'foo': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',  # noqa
+        'bar': {
+            'baz': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'  # noqa
+        }
+    }
+    assert files_tree == expected_files_tree


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-cli/issues/121

Changes:

- `project_dir` is calculated based on where the cli is called from. This would have implications on how the logs file is set. It is now a relative path and should be added the `project_dir` as base. However, as far as I can see the logging config is not being created.
- Relaxes the dependency on click version. Invenio does not have it pin and it gave a pipenv collision with the new 7.1.1 released.

Tested:

- local: Ok
- containers: Ok

**Question**: Shall we follow the same approach with `instance_path` since it is caluclated for each case, is it worth having it written? I think we can just assume is the current env. Meaning, we keep calculating as till now, but we dont write it. It will be calculated on start up.