### PR TITLE
helpers: use 127.0.0.1 instead of localhost

### DIFF
--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -254,7 +254,7 @@ class LocalCommands(object):
         ], env=run_env)
 
         click.secho(
-            'Instance running!\nVisit https://localhost:5000', fg='green')
+            'Instance running!\nVisit https://127.0.0.1:5000', fg='green')
         server.wait()
 
 
@@ -376,7 +376,7 @@ class ContainerizedCommands(object):
         self.update_statics_and_assets(install=install)
 
         click.secho(
-            'Instance running!\nVisit https://localhost', fg='green')
+            'Instance running!\nVisit https://127.0.0.1', fg='green')
 
     def demo(self):
         """Add demo records into the instance."""


### PR DESCRIPTION
- Changes the output text for a successful running site from using
  https://localhost:5000 to https://127.0.0.1:5000, making it consistent
  with output from Flask. Also, Safari is not happy to go to localhost
  with SSL and changing certificates.