### PR TITLE
V0.15.0

### DIFF
--- a/invenio_cli/helpers/cookiecutter_wrapper.py
+++ b/invenio_cli/helpers/cookiecutter_wrapper.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University.
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -49,7 +49,7 @@ class CookiecutterWrapper(object):
                 'cookiecutter-invenio-rdm.git'
             )
             self.template_name = self.extract_template_name(self.template)
-            self.checkout = template_checkout[1] or 'v0.10.0'
+            self.checkout = template_checkout[1] or 'v0.11.0'
 
     def cookiecutter(self):
         """Wrap cookiecutter call."""

--- a/invenio_cli/version.py
+++ b/invenio_cli/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University.
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,4 +12,4 @@ This file is imported by ``invenio_cli.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.14.2'
+__version__ = '0.15.0'


### PR DESCRIPTION
Fails until the 0.11.0 cookiecutter is merged (which relies on invenio-app-rdm)