### PR TITLE
Fix worker invokation for celery >= 5.0.0

### DIFF
--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -242,7 +242,7 @@ class LocalCommands(object):
 
         click.secho("Starting celery worker...", fg="green")
         worker = subprocess.Popen([
-            'pipenv', 'run', 'celery', 'worker', '--app', 'invenio_app.celery'
+            'pipenv', 'run', 'celery', '--app', 'invenio_app.celery', 'worker'
         ])
 
         click.secho("Starting up local (development) server...", fg='green')

--- a/tests/test_helpers/test_commands.py
+++ b/tests/test_helpers/test_commands.py
@@ -301,7 +301,7 @@ def test_localcommands_run(
     run_env['FLASK_ENV'] = 'development'
     expected_calls = [
         call([
-            'pipenv', 'run', 'celery', 'worker', '--app', 'invenio_app.celery'
+            'pipenv', 'run', 'celery', '--app', 'invenio_app.celery', 'worker'
         ]),
         call([
             'pipenv', 'run', 'invenio', 'run', '--cert',


### PR DESCRIPTION
Celery 5.0.0 changed the order of cli arguments.

`--app` is no part of the worker subcommand, it belongs to the parent command.

A invocation of would look like `celery --app=proj worker ...`

See #160 