### PR TITLE
allow 'run' command to pass --host/-h and --port/-p to invenio

### DIFF
--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -122,14 +122,18 @@ def demo(local):
 
 
 @cli.command()
-def run():
+@click.option('--host', '-h',  default='127.0.0.1',
+              help='bind address')
+@click.option('--port', '-p',  default=5000,
+              help='bind port')
+def run(host, port):
     """Starts the local development server.
 
     NOTE: this only makes sense locally so no --local option
     """
     cli_config = CLIConfig()
     commands = LocalCommands(cli_config)
-    commands.run()
+    commands.run(host=host, port=str(port))
 
 
 @cli.command()

--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -228,7 +228,7 @@ class LocalCommands(object):
         command = ['pipenv', 'run', 'invenio', 'rdm-records', 'demo']
         subprocess.run(command, check=True)
 
-    def run(self):
+    def run(self, host, port):
         """Run development server and celery queue."""
         self._ensure_containers_running()
 
@@ -250,11 +250,13 @@ class LocalCommands(object):
         run_env['FLASK_ENV'] = 'development'
         server = subprocess.Popen([
             'pipenv', 'run', 'invenio', 'run', '--cert',
-            'docker/nginx/test.crt', '--key', 'docker/nginx/test.key'
+            'docker/nginx/test.crt', '--key', 'docker/nginx/test.key',
+            '--host', host, '--port', port
         ], env=run_env)
 
         click.secho(
-            'Instance running!\nVisit https://127.0.0.1:5000', fg='green')
+            'Instance running!\nVisit https://{}:{}'.format(host, port),
+            fg='green')
         server.wait()
 
     def destroy(self):

--- a/tests/test_helpers/test_commands.py
+++ b/tests/test_helpers/test_commands.py
@@ -295,7 +295,7 @@ def test_localcommands_run(
         fake_cli_config):
     commands = LocalCommands(fake_cli_config)
 
-    commands.run()
+    commands.run(host='127.0.0.1', port='5000')
 
     run_env = os.environ.copy()
     run_env['FLASK_ENV'] = 'development'
@@ -305,7 +305,8 @@ def test_localcommands_run(
         ]),
         call([
             'pipenv', 'run', 'invenio', 'run', '--cert',
-            'docker/nginx/test.crt', '--key', 'docker/nginx/test.key'
+            'docker/nginx/test.crt', '--key', 'docker/nginx/test.key',
+            '--host', '127.0.0.1', '--port', '5000'
         ], env=run_env),
         call().wait()
     ]


### PR DESCRIPTION
May be of use in respect of #97 - only accepts host and port, but these are probably the most common things to tweak? 
