### PR TITLE
commands: add site hostname config when running local

### DIFF
--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -248,6 +248,7 @@ class LocalCommands(object):
         click.secho("Starting up local (development) server...", fg='green')
         run_env = os.environ.copy()
         run_env['FLASK_ENV'] = 'development'
+        run_env['INVENIO_SITE_HOSTNAME'] = f"{host}:{port}"
         server = subprocess.Popen([
             'pipenv', 'run', 'invenio', 'run', '--cert',
             'docker/nginx/test.crt', '--key', 'docker/nginx/test.key',

--- a/tests/test_helpers/test_commands.py
+++ b/tests/test_helpers/test_commands.py
@@ -267,10 +267,13 @@ def test_localcommands_run(
         fake_cli_config):
     commands = LocalCommands(fake_cli_config)
 
-    commands.run(host='127.0.0.1', port='5000')
+    host = '127.0.0.1'
+    port = '5000'
+    commands.run(host=host, port=port)
 
     run_env = os.environ.copy()
     run_env['FLASK_ENV'] = 'development'
+    run_env['INVENIO_SITE_HOSTNAME'] = f"{host}:{port}"
     expected_calls = [
         call([
             'pipenv', 'run', 'celery', '--app', 'invenio_app.celery', 'worker'


### PR DESCRIPTION
**Open question**
- Do we assume that there is always a port and host? e.g. if I want to run in `mysite.com` I also provide the port (no 443 assumptions if `port == None`)