### PR TITLE
improve services and commands

### DIFF
--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -16,7 +16,6 @@ import click
 from .helpers.cli_config import CLIConfig
 from .helpers.commands import Commands, ContainerizedCommands, LocalCommands
 from .helpers.cookiecutter_wrapper import CookiecutterWrapper
-from .helpers.docker_helper import DockerHelper
 
 
 @click.group()
@@ -106,8 +105,9 @@ def status(verbose):
     NOTE: currently only ES, DB (postgresql/mysql) and redis are supported.
     """
     cli_config = CLIConfig()
-    commands = LocalCommands(cli_config)
-    commands.status(services=["redis", cli_config.get_db_type(), "es"], verbose=verbose)
+    commands = Commands(cli_config)
+    commands.status(
+        services=["redis", cli_config.get_db_type(), "es"], verbose=verbose)
 
 
 @cli.command()
@@ -123,10 +123,7 @@ def containerize(pre, force, install_js):
     Think of it as a production compilation build + running.
     """
     cli_config = CLIConfig()
-    commands = ContainerizedCommands(
-        cli_config,
-        DockerHelper(cli_config.get_project_shortname(), local=False)
-    )
+    commands = ContainerizedCommands(cli_config)
 
     commands.containerize(pre=pre, force=force, install=install_js)
 
@@ -137,7 +134,7 @@ def containerize(pre, force, install_js):
 def demo(local):
     """Populates instance with demo records."""
     cli_config = CLIConfig()
-    commands = Commands(cli_config, local)
+    commands = LocalCommands(cli_config)
     commands.demo()
 
 
@@ -215,7 +212,7 @@ def watch_module(path, link):
 def destroy(verbose):
     """Removes all associated resources (containers, images, volumes)."""
     cli_config = CLIConfig()
-    commands = Commands(cli_config, False)
+    commands = Commands(cli_config)
     commands.destroy()
 
 
@@ -223,7 +220,7 @@ def destroy(verbose):
 def stop():
     """Stops containers."""
     cli_config = CLIConfig()
-    commands = Commands(cli_config, False)
+    commands = Commands(cli_config)
     commands.stop()
 
 
@@ -239,7 +236,7 @@ def upgrade(verbose):
 def shell():
     """Shell command."""
     cli_config = CLIConfig()
-    commands = LocalCommands(cli_config)
+    commands = Commands(cli_config)
     commands.shell()
 
 
@@ -251,7 +248,7 @@ def shell():
 def pyshell(debug):
     """Python shell command."""
     cli_config = CLIConfig()
-    commands = LocalCommands(cli_config)
+    commands = Commands(cli_config)
     commands.pyshell(debug=debug)
 
 
@@ -265,5 +262,5 @@ def ext():
 def module_install(modules):
     """Install a Python module in development mode."""
     cli_config = CLIConfig()
-    commands = Commands(cli_config, True)
+    commands = LocalCommands(cli_config)
     commands.install_modules(modules)

--- a/invenio_cli/cli.py
+++ b/invenio_cli/cli.py
@@ -98,6 +98,19 @@ def services(force):
 
 
 @cli.command()
+@click.option('-v', '--verbose', default=False, is_flag=True, required=False,
+              help='Verbose mode will show all logs in the console.')
+def status(verbose):
+    """Checks if the services are up and running.
+
+    NOTE: currently only ES, DB (postgresql/mysql) and redis are supported.
+    """
+    cli_config = CLIConfig()
+    commands = LocalCommands(cli_config)
+    commands.status(services=["redis", cli_config.get_db_type(), "es"], verbose=verbose)
+
+
+@cli.command()
 @click.option('--pre', default=False, is_flag=True,
               help='If specified, allows the installation of alpha releases')
 @click.option('-f', '--force', default=False, is_flag=True,

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -97,6 +97,10 @@ class CLIConfig(object):
         """Returns the project's shortname."""
         return self.config[CLIConfig.COOKIECUTTER_SECTION]['project_shortname']
 
+    def get_db_type(self):
+        """Returns the database type (mysql, postgresql, sqlite)."""
+        return self.config[CLIConfig.COOKIECUTTER_SECTION]['database']
+
     @classmethod
     def write(cls, project_dir, flavour, replay):
         """Write invenio-cli config file.

--- a/invenio_cli/helpers/commands.py
+++ b/invenio_cli/helpers/commands.py
@@ -21,7 +21,7 @@ from pynpm import NPMPackage
 from . import filesystem
 from .docker_helper import DockerHelper
 from .env import env
-from .services import wait_for_services
+from .services import wait_for_services, HEALTHCHECKS
 
 
 class Commands(object):
@@ -337,6 +337,24 @@ class LocalCommands(object):
             'Instance running!\nVisit https://{}:{}'.format(host, port),
             fg='green')
         server.wait()
+
+    def status(self, services, verbose):
+        """Checks the status of the given service."""
+        project_shortname = self.cli_config.get_project_shortname()
+
+        for service in services:
+            check = HEALTHCHECKS.get(service)
+            if check:
+                if check(
+                    filepath="docker-services.yml",
+                    verbose=verbose,
+                    project_shortname=project_shortname,
+                ):
+                    click.secho(f"{service} up and running.", fg="green")
+                else:
+                    click.secho(f"{service}: unable to connect or bad status response.", fg="red")
+            else:
+                click.secho(f"{service}: no healthcheck function defined.", fg="yellow")
 
     def shell(self):
         """Start a shell in the virtual environment."""

--- a/invenio_cli/helpers/services.py
+++ b/invenio_cli/helpers/services.py
@@ -50,7 +50,7 @@ def es_healthcheck(*args, **kwargs):
     return _run_healthcheck_command([
         "curl",
         "-f",
-        "localhost:9200/_cluster/health?wait_for_status=green"
+        "localhost:9200/_cluster/health?wait_for_status=yellow"
     ], verbose)
 
 
@@ -102,7 +102,7 @@ def redis_healthcheck(*args, **kwargs):
         filepath,
         "exec",
         "-T",
-        "redis",
+        "cache",
         "bash",
         "-c",
         "redis-cli ping",
@@ -144,7 +144,11 @@ def wait_for_services(
         try_ = 1
         # Using plain __import__ to avoid depending on invenio-base
         check = HEALTHCHECKS[service]
-        ready = check(filepath=filepath, verbose=verbose)
+        ready = check(
+            filepath=filepath,
+            verbose=verbose,
+            project_shortname=project_shortname,
+        )
         while not ready and try_ < max_retries:
             click.secho(
                 f"{service} not ready at {try_} retries, waiting " \
@@ -157,7 +161,7 @@ def wait_for_services(
             ready = check(
                 filepath=filepath,
                 verbose=verbose,
-                project_shortname=project_shortname
+                project_shortname=project_shortname,
             )
 
         if not ready:

--- a/invenio_cli/helpers/services.py
+++ b/invenio_cli/helpers/services.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio CLI Service class."""
+
+#####
+# IMPORTANT NOTE: If you are going to modify any code here.
+# Check `docker-service-cli` since the original code belongs there,
+# and any bug might have already been fixed there.
+# The reason for the copy-paste was to simplify the complexity of the
+# integration. Might be integrated in the future when `docker-services-cli`
+# reaches a higher maturity level.
+#####
+
+from os import path
+from subprocess import check_call, Popen, PIPE
+import time
+
+import click
+
+
+def _run_healthcheck_command(command, verbose=False):
+    """Runs a given command, returns True if it succeeds, False otherwise."""
+    p = Popen(command, stdout=PIPE, stderr=PIPE)
+    output, error = p.communicate()
+    output = output.decode("utf-8")
+    error = error.decode("utf-8")
+    if p.returncode == 0:
+        if verbose:
+            click.secho(output, fg="green")
+        return True
+    if p.returncode != 0:
+        if verbose:
+            click.secho(
+                f"Healthcheck failed.\nOutput: {output}\nError:{error}",
+                fg="red"
+            )
+        return False
+
+
+def es_healthcheck(*args, **kwargs):
+    """Elasticsearch healthcheck."""
+    verbose = kwargs['verbose']
+
+    return _run_healthcheck_command([
+        "curl",
+        "-f",
+        "localhost:9200/_cluster/health?wait_for_status=green"
+    ], verbose)
+
+
+def postgresql_healthcheck(*args, **kwargs):
+    """Postgresql healthcheck."""
+    filepath = kwargs['filepath']
+    verbose = kwargs['verbose']
+
+    return _run_healthcheck_command([
+        "docker-compose",
+        "--file",
+        filepath,
+        "exec",
+        "-T",
+        "db",
+        "bash",
+        "-c",
+        "pg_isready",
+    ], verbose)
+
+
+def mysql_healthcheck(*args, **kwargs):
+    """Mysql healthcheck."""
+    filepath = kwargs['filepath']
+    verbose = kwargs['verbose']
+    password = kwargs['project_shortname']
+
+    return _run_healthcheck_command([
+        "docker-compose",
+        "--file",
+        filepath,
+        "exec",
+        "-T",
+        "db",
+        "bash",
+        "-c",
+        f"mysql -p{password} -e \"select Version();\"",
+    ], verbose)
+
+
+def redis_healthcheck(*args, **kwargs):
+    """Redis healthcheck."""
+    filepath = kwargs['filepath']
+    verbose = kwargs['verbose']
+
+    return _run_healthcheck_command([
+        "docker-compose",
+        "--file",
+        filepath,
+        "exec",
+        "-T",
+        "redis",
+        "bash",
+        "-c",
+        "redis-cli ping",
+        "|",
+        "grep 'PONG'",
+        "&>/dev/null;",
+    ], verbose)
+
+
+HEALTHCHECKS = {
+    "es": es_healthcheck,
+    "postgresql": postgresql_healthcheck,
+    "mysql": mysql_healthcheck,
+    "redis": redis_healthcheck,
+    "sqlite": (lambda *args, **kwargs: True)
+}
+"""Health check functions module path, as string."""
+
+
+def wait_for_services(
+    services,
+    project_shortname,
+    filepath="docker-services.yml",
+    max_retries=6,
+    verbose=False,
+    ):
+    """Wait for services to be up.
+
+    It performs configured healthchecks in a serial fashion, following the
+    order given in the ``up`` command. If the services is an empty list, to be
+    compliant with `docker-compose` it will perform the healthchecks of all the
+    services.
+    """
+    if len(services) == 0:
+        services = HEALTHCHECKS.keys()
+
+    for service in services:
+        exp_backoff_time = 2
+        try_ = 1
+        # Using plain __import__ to avoid depending on invenio-base
+        check = HEALTHCHECKS[service]
+        ready = check(filepath=filepath, verbose=verbose)
+        while not ready and try_ < max_retries:
+            click.secho(
+                f"{service} not ready at {try_} retries, waiting " \
+                f"{exp_backoff_time}s",
+                fg="yellow"
+            )
+            try_ += 1
+            time.sleep(exp_backoff_time)
+            exp_backoff_time *= 2
+            ready = check(
+                filepath=filepath,
+                verbose=verbose,
+                project_shortname=project_shortname
+            )
+
+        if not ready:
+            click.secho(f"Unable to boot up {service}", fg="red")
+            exit(1)
+        else:
+            click.secho(f"{service} up and running!", fg="green")

--- a/invenio_cli/helpers/services.py
+++ b/invenio_cli/helpers/services.py
@@ -17,9 +17,9 @@
 # reaches a higher maturity level.
 #####
 
-from os import path
-from subprocess import check_call, Popen, PIPE
 import time
+from os import path
+from subprocess import PIPE, Popen, check_call
 
 import click
 
@@ -128,7 +128,7 @@ def wait_for_services(
     filepath="docker-services.yml",
     max_retries=6,
     verbose=False,
-    ):
+):
     """Wait for services to be up.
 
     It performs configured healthchecks in a serial fashion, following the
@@ -151,7 +151,7 @@ def wait_for_services(
         )
         while not ready and try_ < max_retries:
             click.secho(
-                f"{service} not ready at {try_} retries, waiting " \
+                f"{service} not ready at {try_} retries, waiting " +
                 f"{exp_backoff_time}s",
                 fg="yellow"
             )


### PR DESCRIPTION
**Requires**
- https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/124
    - Change containers restart policy to `unless-stopped`.
    - Remove unused services from `docker-services.yml`: flower, kibana, lb

**Changes**
- Adds healthchecks. Closes #53 
![Screenshot 2020-11-20 at 11 21 52](https://user-images.githubusercontent.com/6756943/99791056-554fa780-2b25-11eb-8c87-240a086def18.png)
- Elasticseach healthcheck takes into account status `yellow` (not `green`). Since it uses a single node, ES is `yellow` because there is risk of loosing data (i.e. no proper sharding/replication). When fully *not ready* status is`red`.
- Status command to check the services are up and running (i.e. `invenio-cli status`). Currently it is only a *generic* command, which works both for local and containerize. However, it only checks redis, es and db (i.e. no web apps, nor workers) because the healthchecks are not implemented. Closes #175 
![Screenshot 2020-11-20 at 11 39 42](https://user-images.githubusercontent.com/6756943/99791148-7f08ce80-2b25-11eb-8c93-be279887e59b.png)
![Screenshot 2020-11-20 at 11 39 36](https://user-images.githubusercontent.com/6756943/99791155-80d29200-2b25-11eb-9593-8d9d6f93b66d.png)
- Small refactor of the `commands.py`. The `Commands` class was a factory and not being used as such. In addition, it was forcing to pass the `local` parameter which many times was just force by the lower implementation of the function in a children class. I refactored it into a parent class with the common methods (destroy, stop, status, etc.) and made use of inheritance in the `cli.py` module.
- Assets re-build/copy is only allowed in local development mode. When using the containerized version re-building the image is required. Thanks to docker cache, only the npm/build part is done (e.g. no locking again, no re-installing python deps, etc.). Closes https://github.com/inveniosoftware/invenio-cli/issues/178. **Important** see question related to `containerize` in the below section.
![Screenshot 2020-11-20 at 13 29 31](https://user-images.githubusercontent.com/6756943/99800335-7ec3ff80-2b34-11eb-92ca-2124399c9969.png)


**Missing/Questions**:
- RabbitMQ and Celery healthchecks. To be implemented in `docker-services-cli`.
- Clarify integration/importing of `docker-services-cli`
    - If just re-using *copy-pasted* code, use `docker_helper` to call certain helthchecks.
    - This would greatly improve some things like `commands.py:status` which at the moment is hardcoding the docker-services file.
- `containerize`:
    - Can avoid installing python deps (if lock file exists) --> should allow `--skip-lock` like in local development installation?
    - Can avoid installing js deps (by passing `--no-install-js`)
    - Cannot avoid building assets. Should be allowed in case is just a "re-run" of a stopped instance (i.e. nothing changed).