### PR TITLE
Change Python version check

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ MIT License
 
 Copyright (C) 2019 CERN.
 Copyright (C) 2019 Northwestern University.
+Copyright (C) 2021 TU Wien.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2021 TU Wien.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -8,6 +9,7 @@
 """Invenio module to ease the creation and management of applications."""
 
 import re
+import sys
 from os import listdir
 
 from ..helpers.process import ProcessResponse, run_cmd, run_interactive
@@ -72,10 +74,17 @@ class RequirementsCommands(object):
 
     @classmethod
     def check_python_version(cls, major, minor=-1, patch=-1, exact=False):
-        """Check the node version."""
-        # Output comes in the form of 'Python 3.7.7\n'
-        result = run_cmd(["python", "--version"])
-        version = cls._version_from_string(result.output.strip())
+        """Check the python version."""
+        # check the version of the currently executed Python, as
+        # 'invenio-cli' will create a virtualenv with the stated Python
+        # version (via pipenv) anyway
+        version_info = sys.version_info
+        version = "{}.{}.{}".format(
+            version_info.major,
+            version_info.minor,
+            version_info.micro,
+        )
+
         return cls._check_version(
             "Python", version, major, minor, patch, exact)
 


### PR DESCRIPTION
closes #214 

* previously, 'python' would be called to determine the version, which
  is symlinked to 'python2' on some systems (e.g. Debian 10)
* python2 apparently prints its version information to stderr instead of
  stdout
* instead of calling a 'python --version' subprocess, we now check the
  python version executing 'invenio-cli', as the latter will create a
  new virtualenv with the stated python version for invenio rdm (via
  pipenv) anyway