### PR TITLE
cli: separate vocabulary creation from demo record creation

### DIFF
--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -159,6 +159,21 @@ class ContainersCommands(ServicesCommands):
 
         return steps
 
+    def vocabularies(self, project_shortname):
+        """Steps to set up the required vocabularies for the instance."""
+        steps = [
+            FunctionStep(
+                func=self.docker_helper.execute_cli_command,
+                args={
+                    "project_shortname": project_shortname,
+                    "command": "invenio rdm-records vocabularies"
+                },
+                message="Creating vocabularies..."
+            )
+        ]
+
+        return steps
+
     def setup(self, force, demo_data=True, stop=False, services=True):
         """Return the steps to setup containerize services.
 
@@ -182,6 +197,7 @@ class ContainersCommands(ServicesCommands):
             steps.extend(self._cleanup(project_shortname))
 
         steps.extend(self._setup(project_shortname))
+        steps.extend(self.vocabularies(project_shortname))
 
         if demo_data:
             steps.extend(self.demo(project_shortname))

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -142,7 +142,20 @@ class ServicesCommands(Commands):
             CommandStep(
                 cmd=['pipenv', 'run', 'invenio', 'rdm-records', 'demo'],
                 env={'PIPENV_VERBOSITY': "-1"},
-                message="Creatin demo records..."
+                message="Creating demo records..."
+            )
+        ]
+
+        return steps
+
+    def vocabularies(self):
+        """Steps to set up the required vocabularies for the instance."""
+        command = ['pipenv', 'run', 'invenio', 'rdm-records', 'vocabularies']
+        steps = [
+            CommandStep(
+                cmd=command,
+                env={'PIPENV_VERBOSITY': "-1"},
+                message="Creating vocabularies..."
             )
         ]
 
@@ -165,6 +178,7 @@ class ServicesCommands(Commands):
             steps.extend(self._cleanup())
 
         steps.extend(self._setup())
+        steps.extend(self.vocabularies())
 
         if demo_data:
             steps.extend(self.demo())


### PR DESCRIPTION
closes inveniosoftware/invenio-rdm-records#347

* allows the cration of required vocabularies without creating demo records

this will likely require a dependency bump for `invenio-rdm-records` somewhere (`invenio-app-rdm`, and `cookiecutter-invenio-rdm`?)
otherwise, `invenio-cli setup` will fail due to the command `invenio rdm-records vocabularies` being unknown