### PR TITLE
setup: call rdm-records fixtures instead of vocabularies

### DIFF
--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -159,16 +159,16 @@ class ContainersCommands(ServicesCommands):
 
         return steps
 
-    def vocabularies(self, project_shortname):
-        """Steps to set up the required vocabularies for the instance."""
+    def fixtures(self, project_shortname):
+        """Steps to set up the required fixtures for the instance."""
         steps = [
             FunctionStep(
                 func=self.docker_helper.execute_cli_command,
                 args={
                     "project_shortname": project_shortname,
-                    "command": "invenio rdm-records vocabularies"
+                    "command": "invenio rdm-records fixtures"
                 },
-                message="Creating vocabularies..."
+                message="Creating fixtures..."
             )
         ]
 
@@ -197,7 +197,7 @@ class ContainersCommands(ServicesCommands):
             steps.extend(self._cleanup(project_shortname))
 
         steps.extend(self._setup(project_shortname))
-        steps.extend(self.vocabularies(project_shortname))
+        steps.extend(self.fixtures(project_shortname))
 
         if demo_data:
             steps.extend(self.demo(project_shortname))

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -148,14 +148,14 @@ class ServicesCommands(Commands):
 
         return steps
 
-    def vocabularies(self):
-        """Steps to set up the required vocabularies for the instance."""
-        command = ['pipenv', 'run', 'invenio', 'rdm-records', 'vocabularies']
+    def fixtures(self):
+        """Steps to set up the required fixtures for the instance."""
+        command = ['pipenv', 'run', 'invenio', 'rdm-records', 'fixtures']
         steps = [
             CommandStep(
                 cmd=command,
                 env={'PIPENV_VERBOSITY': "-1"},
-                message="Creating vocabularies..."
+                message="Creating fixtures..."
             )
         ]
 
@@ -178,7 +178,7 @@ class ServicesCommands(Commands):
             steps.extend(self._cleanup())
 
         steps.extend(self._setup())
-        steps.extend(self.vocabularies())
+        steps.extend(self.fixtures())
 
         if demo_data:
             steps.extend(self.demo())


### PR DESCRIPTION
* the rdm-records cli command for setting up the fixtures has
  previously been called vocabularies, but it has been renamed
  since it does more than only set up vocabularies

requires https://github.com/inveniosoftware/invenio-rdm-records/pull/395