### PR TITLE
requirements: require exact node version 14

### DIFF
--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -46,13 +46,13 @@ class RequirementsCommands(object):
                       f"Got {parts[0]} expected {major}",
                 status_code=1
             )
-        if (exact and parts[1] != minor) or parts[1] < minor:
+        if (exact and parts[1] != minor and minor != -1) or parts[1] < minor:
             return ProcessResponse(
                 error=f"{binary} minor version missmatch. "
                       f"Got {parts[1]} expected {minor}",
                 status_code=1
             )
-        if (exact and parts[2] != patch) or parts[2] < patch:
+        if (exact and parts[2] != patch and patch != -1) or parts[2] < patch:
             return ProcessResponse(
                 error=f"{binary} patch version missmatch. "
                       f"Got {parts[2]} expected {patch}",
@@ -145,7 +145,7 @@ class RequirementsCommands(object):
         steps = [
             FunctionStep(
                 func=cls.check_node_version,
-                args={"major": 14},
+                args={"major": 14, "exact": True},
                 message="Checking Node version..."
             )
         ]


### PR DESCRIPTION
Fixes https://github.com/inveniosoftware/invenio-cli/issues/227 doing a couple of things:

- Sets the `exact`flag to True in the node version checking, thus moving the requirement condition from ">=14" to "==14"
- Since the `exact` flag is currently implemented to have a global effect (e.g. `exact` with `major=14` will fail with any 14.x.x since it expects exact values for minor and patches too), the proposed change makes the check logic consider `-1`(the default value for unspecified numbers) as a * wildcard. This means that `exact` with `major=14` now passes with any 14.x.x, but fails if a (mismatching) minor is specified.

I can't think of any other solution not requiring the rewrite of the entire version checking logic to accept actual version ranges and wildcards so I think this is an acceptable middle ground.