### PR TITLE
cli: warning messages do not exit

### DIFF
--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2021 TU Wien.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
@@ -195,7 +195,8 @@ class RequirementsCommands(object):
             FunctionStep(
                 func=cls.check_imagemagick_version,
                 args={"major": 0, "minor": 0},
-                message="Checking ImageMagick version..."
+                message="Checking ImageMagick version...",
+                skippable=True,
             )
         ]
 

--- a/invenio_cli/commands/steps.py
+++ b/invenio_cli/commands/steps.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2021 CERN.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,35 +10,52 @@
 from ..helpers.process import run_interactive
 
 
-class FunctionStep(object):
+class Step(object):
+    """Interface for step objects."""
+
+    def __init__(self, message=None, skippable=False):
+        """Constructor."""
+        self.message = message
+        self.skippable = skippable
+
+    def execute(self):
+        """Execute the step."""
+        raise NotImplementedError
+
+
+class FunctionStep(Step):
     """A step which execution is a function call.
 
     Is composed of a function, arguments, and a message (feedback).
     """
 
-    def __init__(self, func, args=None, message=None):
+    def __init__(self, func, args=None, **kwargs):
         """Constructor."""
+        super().__init__(**kwargs)
         self.func = func
         self.args = args or {}
-        self.message = message
 
     def execute(self):
         """Execute the function with the given arguments."""
-        return self.func(**self.args)
+        response = self.func(**self.args)
+        if self.skippable:
+            response.warning = True
+            response.status_code = 0
+
+        return response
 
 
-class CommandStep(object):
+class CommandStep(Step):
     """A step which execution is a command run.
 
     Is composed of a command, an environment, and a message (feedback).
     """
 
-    def __init__(self, cmd, env=None, message=None, skippable=False):
+    def __init__(self, cmd, env=None, **kwargs):
         """Constructor."""
+        super().__init__(**kwargs)
         self.cmd = cmd
         self.env = env
-        self.message = message
-        self.skippable = skippable
 
     def execute(self):
         """Execute the function with the given arguments."""

--- a/tests/commands/test_steps.py
+++ b/tests/commands/test_steps.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module for step tests."""
+
+from invenio_cli.commands.steps import FunctionStep
+from invenio_cli.helpers.process import ProcessResponse
+
+
+def func():
+    return ProcessResponse(
+        error="test",
+        output="test",
+        status_code=1,
+        warning=False
+    )
+
+
+def test_func_step():
+    step = FunctionStep(func=func, args={}, message="")
+    response = step.execute()
+
+    assert response.status_code == 1
+    assert not response.warning
+
+
+def test_skip_func_step():
+    step = FunctionStep(func=func, args={}, message="", skippable=True)
+    response = step.execute()
+
+    assert response.status_code == 0
+    assert response.warning


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-cli/issues/249

A warning always get's an exit code `> 0`. The difference with an error is that it should not exit the program.