### PR TITLE
cli: ensure pipenv command is running inside created project dir

### DIFF
--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -88,7 +88,7 @@ def init(flavour, template, checkout):
 
         click.secho("Writing invenio-invenio_cli config file...", fg='green')
         saved_replay = cookiecutter_wrapper.get_replay()
-        instance_path = calculate_instance_path()
+        instance_path = calculate_instance_path(project_dir)
         CLIConfig.write(project_dir, flavour, saved_replay, instance_path)
 
         click.secho("Creating logs directory...", fg='green')

--- a/invenio_cli/cli/utils.py
+++ b/invenio_cli/cli/utils.py
@@ -7,6 +7,8 @@
 
 """Invenio module to ease the creation and management of applications."""
 
+import os
+
 import click
 
 from ..helpers.cli_config import CLIConfig
@@ -41,10 +43,15 @@ def run_steps(steps, fail_message, success_message):
         click.secho(message=success_message, fg="green")
 
 
-def calculate_instance_path():
+def calculate_instance_path(project_dir):
     """Caclulates instance path based on current venv."""
+    # Ensure pipenv command is running inside the project directory
+    saved_current_path = os.getcwd()
+    os.chdir(project_dir)
     result = run_cmd(
             ['pipenv', 'run', 'invenio', 'shell', '--no-term-title',
                 '-c', '"print(app.instance_path, end=\'\')"']
         )
+    os.chdir(saved_current_path)
+
     return result.output.strip()


### PR DESCRIPTION
* Avoids creating an extra Pipenv file when running `calculate_instance_path`

closes https://github.com/inveniosoftware/invenio-cli/issues/260