### PR TITLE
steps: output logic for function step execute with warning

### DIFF
--- a/invenio_cli/commands/steps.py
+++ b/invenio_cli/commands/steps.py
@@ -38,7 +38,8 @@ class FunctionStep(Step):
     def execute(self):
         """Execute the function with the given arguments."""
         response = self.func(**self.args)
-        if self.skippable:
+
+        if response.status_code > 0 and self.skippable:
             response.warning = True
             response.status_code = 0
 


### PR DESCRIPTION
- closes #257 
- 
The logic was incorrect:

- Previous: a command marked as `skippable` (i.e. soft check) was being shown as a warning independently of the status code (i.e. fail or not)
- Current: a command marked as `skippable` (i.e. soft check) is being shown as warning only if the check fails.

![Screenshot 2021-07-30 at 13 25 22](https://user-images.githubusercontent.com/6756943/127646355-9ffc3ac1-d990-4937-af6a-6907c0e3fba6.png)
