### PR TITLE
config: remove need for pre-existing .invenio.private per team member

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ target/
 # Vim swapfiles
 .*.sw?
 .DS_Store
+
+.vscode/

--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -23,7 +23,7 @@ from .containers import containers
 from .install import install
 from .packages import packages
 from .services import services
-from .utils import calculate_instance_path, pass_cli_config, run_steps
+from .utils import pass_cli_config, run_steps
 
 
 @click.group()
@@ -88,8 +88,7 @@ def init(flavour, template, checkout):
 
         click.secho("Writing invenio-invenio_cli config file...", fg='green')
         saved_replay = cookiecutter_wrapper.get_replay()
-        instance_path = calculate_instance_path(project_dir)
-        CLIConfig.write(project_dir, flavour, saved_replay, instance_path)
+        CLIConfig.write(project_dir, flavour, saved_replay)
 
         click.secho("Creating logs directory...", fg='green')
         os.mkdir(Path(project_dir) / "logs")

--- a/invenio_cli/cli/install.py
+++ b/invenio_cli/cli/install.py
@@ -10,7 +10,6 @@
 import click
 
 from ..commands import InstallCommands
-from ..helpers.cli_config import CLIConfig
 from .utils import pass_cli_config, run_steps
 
 

--- a/invenio_cli/cli/services.py
+++ b/invenio_cli/cli/services.py
@@ -11,7 +11,6 @@
 import click
 
 from ..commands import Commands, ServicesCommands
-from ..helpers.cli_config import CLIConfig
 from .utils import pass_cli_config, run_steps
 
 

--- a/invenio_cli/cli/utils.py
+++ b/invenio_cli/cli/utils.py
@@ -7,12 +7,9 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-import os
-
 import click
 
 from ..helpers.cli_config import CLIConfig
-from ..helpers.process import run_cmd
 
 pass_cli_config = click.make_pass_decorator(CLIConfig, ensure=True)
 
@@ -41,17 +38,3 @@ def run_steps(steps, fail_message, success_message):
             click.secho(message=result.output, fg="green")
     else:
         click.secho(message=success_message, fg="green")
-
-
-def calculate_instance_path(project_dir):
-    """Caclulates instance path based on current venv."""
-    # Ensure pipenv command is running inside the project directory
-    saved_current_path = os.getcwd()
-    os.chdir(project_dir)
-    result = run_cmd(
-            ['pipenv', 'run', 'invenio', 'shell', '--no-term-title',
-                '-c', '"print(app.instance_path, end=\'\')"']
-        )
-    os.chdir(saved_current_path)
-
-    return result.output.strip()

--- a/invenio_cli/version.py
+++ b/invenio_cli/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_cli.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,12 +1,23 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University.
+# Copyright (C) 2019-2021 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+
+pytest_args=()
+for arg in $@; do
+	# note: we don't use "getopts" here b/c of some limitations (e.g. long options),
+	#       which means that we can't combine short options (e.g. "./run-tests -Kk pattern")
+    pytest_args+=( ${arg} )
+done
+
+
 python -m check_manifest --ignore ".*-requirements.txt" && \
 python -m sphinx.cmd.build -qnNW docs docs/_build/html && \
-python -m pytest
+# Note: expansion of pytest_args looks like below to not cause an unbound
+# variable error when 1) "nounset" and 2) the array is empty.
+python -m pytest ${pytest_args[@]+"${pytest_args[@]}"}

--- a/tests/helpers/test_cli_config.py
+++ b/tests/helpers/test_cli_config.py
@@ -1,26 +1,24 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019-2020 CERN.
-# Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C) 2019-2021 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Module config_file tests."""
-import os
 import tempfile
-from configparser import ConfigParser
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from invenio_cli.errors import InvenioCLIConfigError
 from invenio_cli.helpers.cli_config import CLIConfig
 
 
 def test_cli_config_write():
     """Check config file is generated: preliminary superficial test."""
-
     tmp_dir = tempfile.TemporaryDirectory()
     project_dir = tmp_dir.name
     flavour = 'RDM'
@@ -43,13 +41,13 @@ def test_cli_config_write():
     private_config_path = Path(project_dir) / CLIConfig.PRIVATE_CONFIG_FILENAME
 
     # No configuration files
-    assert not os.path.isfile(config_path)
-    assert not os.path.isfile(private_config_path)
+    assert not config_path.is_file()
+    assert not private_config_path.is_file()
 
     CLIConfig.write(project_dir, flavour, replay)
 
-    assert os.path.isfile(config_path)
-    assert os.path.isfile(private_config_path)
+    assert config_path.is_file()
+    assert private_config_path.is_file()
 
 
 @pytest.fixture
@@ -96,12 +94,12 @@ def test_cli_config_get_project_dir(config_dir):
 def test_cli_config_instance_path(config_dir):
     cli_config = CLIConfig(config_dir)
 
-    assert cli_config.get_instance_path() == Path('')
+    with pytest.raises(InvenioCLIConfigError):
+        cli_config.get_instance_path()
 
     # Update instance path to now see if we retrieve it
-    instance_path = os.path.join(config_dir, '.venv/')
+    instance_path = config_dir / '.venv/'
     cli_config.update_instance_path(instance_path)
-
     assert cli_config.get_instance_path() == Path(instance_path)
 
 


### PR DESCRIPTION
closes #130

To summarize: as part of a team I want to clone the instance repository and run `invenio-cli install` ... without having to artificially create a `.invenio.private` with a path to a virtualenv that I also need to create. This had to be done before because these steps were done by `invenio-cli init` which isn't run because my teammate already ran it (I am cloning the result of that command afterall). This is also handy even without teammates, if one is cloning the repo on a different computer.  

This PR addresses that by relying on the in-memory project directory directly (no need to look-up the `.invenio.private` file) and the fact that `invenio-cli install` sets the instance location. Even though we technically still rely on .invenio.private for it, it should really be thought as a cache that is primed before use by `invenio-cli install`. 


