### PR TITLE
setup: bump click dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ for reqs in extras_require.values():
 
 install_requires = [
     'cookiecutter>=1.7.1,<1.8.0',
-    'click>=7.1.1,<8.0',
+    'click>=7.1.1,<8.1',
     'click-default-group>=1.2.2,<2.0.0',
     'docker>=4.1.0,<6.0.0',
     'pipenv>=2020.6.2',


### PR DESCRIPTION
Allow the 8.0.X releases of `click` (which is required by newer releases of `black`), as the change log doesn't show any breaking changes that'd be relevant for us: https://click.palletsprojects.com/en/8.0.x/changes/