### PR TITLE
Add support for `poetry` as an optional, alternative packaging backend

### DIFF
--- a/invenio_cli/cli/assets.py
+++ b/invenio_cli/cli/assets.py
@@ -8,7 +8,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 import click
-from click_default_group import DefaultGroup
 
 from ..commands import AssetsCommands
 from .utils import pass_cli_config, run_steps

--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -45,8 +45,15 @@ invenio_cli.add_command(services)
               help='Check development requirements.')
 def check_requirements(development):
     """Checks the system fulfills the pre-requirements."""
+    try:
+        # the 'check-requirements' command should probably be available
+        # from outside the project directory as well
+        cli_config = CLIConfig()
+    except FileNotFoundError:
+        cli_config = None
+
     click.secho("Checking pre-requirements...", fg="green")
-    steps = RequirementsCommands.check(development)
+    steps = RequirementsCommands(cli_config).check(development)
     on_fail = "Pre requisites not met."
     on_success = "All requisites are fulfilled."
 
@@ -54,17 +61,19 @@ def check_requirements(development):
 
 
 @invenio_cli.command()
-def shell():
+@pass_cli_config
+def shell(cli_config):
     """Shell command."""
-    Commands.shell()
+    Commands(cli_config).shell()
 
 
 @invenio_cli.command()
+@pass_cli_config
 @click.option('--debug/--no-debug', '-d/', default=False, is_flag=True,
               help='Enable Flask development mode (default: disabled).')
-def pyshell(debug):
+def pyshell(cli_config, debug):
     """Python shell command."""
-    Commands.pyshell(debug=debug)
+    Commands(cli_config).pyshell(debug=debug)
 
 
 @invenio_cli.command()
@@ -151,9 +160,10 @@ def destroy(cli_config):
 @click.option('--script', required=True,
               help='The path of custom migration script.'
               )
-def upgrade(script):
+@pass_cli_config
+def upgrade(cli_config, script):
     """Upgrades the current instance to a newer version."""
-    steps = UpgradeCommands.upgrade(script)
+    steps = UpgradeCommands(cli_config).upgrade(script)
     on_fail = "Upgrade failed."
     on_success = "Upgrade sucessfull."
 

--- a/invenio_cli/cli/packages.py
+++ b/invenio_cli/cli/packages.py
@@ -32,7 +32,7 @@ def lock(cli_config, pre, dev):
         f"Include dev-packages: {dev}.",
         fg="green"
     )
-    steps = PackagesCommands.lock(pre, dev)
+    steps = PackagesCommands(cli_config).lock(pre, dev)
     on_fail = "Failed to lock dependencies."
     on_success = "Dependencies locked successfully."
 
@@ -49,7 +49,7 @@ def install(cli_config, packages, skip_build):
     if len(packages) < 1:
         raise click.UsageError("You must specify at least one package.")
 
-    steps = PackagesCommands.install_packages(packages)
+    steps = PackagesCommands(cli_config).install_packages(packages)
 
     on_fail = f"Failed to install packages {packages}."
     on_success = f"Packages {packages} installed successfully."
@@ -67,8 +67,9 @@ def install(cli_config, packages, skip_build):
 @pass_cli_config
 def outdated(cli_config):
     """Show outdated Python dependencies."""
-    steps = PackagesCommands.outdated_packages()
+    steps = PackagesCommands(cli_config).outdated_packages()
 
+    # TODO poetry still exits with 0, even if there's outdated packages
     on_fail = "Some of the packages need to be updated."
     on_success = "All packages are up to date."
 
@@ -80,15 +81,16 @@ def outdated(cli_config):
 @pass_cli_config
 def update(cli_config, version=None):
     """Update all or some Python python packages."""
+    pkg_commands = PackagesCommands(cli_config)
     if version:
         db = cli_config.get_db_type()
         es = f"elasticsearch{cli_config.get_es_version()}"
         package = f"invenio-app-rdm[{db},{es}]~="
-        steps = PackagesCommands.update_package_new_version(package, version)
+        steps = pkg_commands.update_package_new_version(package, version)
         on_fail = f"Failed to update version {version}"
         on_success = f"Version {version} installed successfully."
     else:
-        steps = PackagesCommands.update_packages()
+        steps = pkg_commands.update_packages()
         on_fail = "Failed to update packages."
         on_success = "Packages installed successfully."
 

--- a/invenio_cli/cli/services.py
+++ b/invenio_cli/cli/services.py
@@ -10,7 +10,7 @@
 
 import click
 
-from ..commands import Commands, ServicesCommands
+from ..commands import ServicesCommands
 from .utils import pass_cli_config, run_steps
 
 

--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -16,6 +16,7 @@ import click
 from pynpm import NPMPackage
 
 from ..helpers import env
+from ..helpers.packaging import get_packaging_backend
 from ..helpers.process import ProcessResponse, run_interactive
 from .local import LocalCommands
 from .steps import CommandStep, FunctionStep
@@ -125,8 +126,9 @@ class AssetsCommands(LocalCommands):
     def watch_assets(self):
         """High-level command to watch assets for changes."""
         # Commands
-        prefix = ['pipenv', 'run']
-        watch_cmd = prefix + ['invenio', 'webpack', 'run', 'start']
+        watch_cmd = get_packaging_backend(self.cli_config).run_command(
+            "invenio", "webpack", "run", "start"
+        )
 
         with env(FLASK_ENV='development'):
             # Collect into statics/ and assets/ folder

--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -9,7 +9,6 @@
 
 
 import subprocess
-from functools import partial
 from pathlib import Path
 
 import click
@@ -19,7 +18,7 @@ from ..helpers import env
 from ..helpers.packaging import get_packaging_backend
 from ..helpers.process import ProcessResponse, run_interactive
 from .local import LocalCommands
-from .steps import CommandStep, FunctionStep
+from .steps import FunctionStep
 
 
 class AssetsCommands(LocalCommands):
@@ -80,7 +79,7 @@ class AssetsCommands(LocalCommands):
             )
         else:
             return ProcessResponse(
-                error=f"Unable to install dependent packages. "
+                error="Unable to install dependent packages. "
                       "Got error code {status_code}",
                 status_code=status_code
             )

--- a/invenio_cli/commands/commands.py
+++ b/invenio_cli/commands/commands.py
@@ -8,6 +8,7 @@
 """Invenio module to ease the creation and management of applications."""
 
 from ..helpers.env import env
+from ..helpers.packaging import get_packaging_backend
 from ..helpers.process import run_interactive
 from .steps import CommandStep
 
@@ -22,17 +23,17 @@ class Commands(object):
         """
         self.cli_config = cli_config
 
-    @classmethod
-    def shell(cls):
+    def shell(self):
         """Start a shell in the virtual environment."""
-        command = ['pipenv', 'shell', ]
+        command = get_packaging_backend(self.cli_config).shell_command()
         return run_interactive(command, env={'PIPENV_VERBOSITY': "-1"})
 
-    @classmethod
-    def pyshell(cls, debug=False):
+    def pyshell(self, debug=False):
         """Start a Python shell."""
         with env(FLASK_ENV='development' if debug else 'production'):
-            command = ['pipenv', 'run', 'invenio', 'shell']
+            command = get_packaging_backend(self.cli_config).run_command(
+                "invenio", "shell"
+            )
             return run_interactive(command, env={'PIPENV_VERBOSITY': "-1"})
 
     def destroy(self):
@@ -41,9 +42,10 @@ class Commands(object):
         NOTE: This function has no knowledge of the existence of services.
               Refer to services.py to destroy services' containers.
         """
+        command = get_packaging_backend(self.cli_config).remove_venv_command()
         steps = [
             CommandStep(
-                cmd=['pipenv', '--rm'],
+                cmd=command,
                 env={'PIPENV_VERBOSITY': "-1"},
                 message="Destroying virtual environment"
             )

--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -10,7 +10,6 @@
 from ..helpers.docker_helper import DockerHelper
 from .packages import PackagesCommands
 from .services import ServicesCommands
-from .services_health import HEALTHCHECKS
 from .steps import FunctionStep
 
 
@@ -82,7 +81,8 @@ class ContainersCommands(ServicesCommands):
                 },
                 message="Purging queues..."
             ),
-            FunctionStep(func=self.cli_config.update_services_setup,
+            FunctionStep(
+                func=self.cli_config.update_services_setup,
                 args={"is_setup": False},
                 message="Updating service setup status (False)..."
             )

--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -23,6 +23,7 @@ class ContainersCommands(ServicesCommands):
             DockerHelper(cli_config.get_project_shortname(), local=False)
 
         super(ContainersCommands, self).__init__(cli_config, docker_helper)
+        self.pkg_commands = PackagesCommands(cli_config)
 
     def build(self, pull=True, cache=True):
         """Return the steps to build images.
@@ -32,7 +33,7 @@ class ContainersCommands(ServicesCommands):
         """
         steps = [
             FunctionStep(
-                func=PackagesCommands.is_locked,
+                func=self.pkg_commands.is_locked,
                 message="Checking if dependencies are locked."
             ),
             FunctionStep(
@@ -227,7 +228,7 @@ class ContainersCommands(ServicesCommands):
 
         if lock:
             # FIXME: Should this params be accepted? sensible defaults?
-            steps.extend(PackagesCommands.lock(pre=True, dev=True))
+            steps.extend(self.pkg_commands.lock(pre=True, dev=True))
 
         if build:
             steps.extend(self.build())

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -7,12 +7,12 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-from ..helpers import env, filesystem
+from ..helpers import filesystem
 from ..helpers.packaging import get_packaging_backend
 from ..helpers.process import run_cmd
 from .local import LocalCommands
 from .packages import PackagesCommands
-from .steps import CommandStep, FunctionStep
+from .steps import FunctionStep
 
 
 class InstallCommands(LocalCommands):
@@ -70,21 +70,21 @@ class InstallCommands(LocalCommands):
             FunctionStep(
                 func=self.symlink_project_file_or_folder,
                 args={"target": 'invenio.cfg'},
-                message=f"Symlinking 'invenio.cfg'..."
+                message="Symlinking 'invenio.cfg'..."
             )
             )
         steps.append(
             FunctionStep(
                 func=self.symlink_project_file_or_folder,
                 args={"target": 'templates'},
-                message=f"Symlinking 'templates'..."
+                message="Symlinking 'templates'..."
             )
             )
         steps.append(
             FunctionStep(
                 func=self.symlink_project_file_or_folder,
                 args={"target": 'app_data'},
-                message=f"Symlinking 'app_data'..."
+                message="Symlinking 'app_data'..."
             )
         )
         steps.append(

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -11,7 +11,7 @@ import signal
 from distutils.dir_util import copy_tree
 from os import environ
 from pathlib import Path
-from subprocess import Popen as popen
+from subprocess import Popen
 
 import click
 
@@ -124,7 +124,7 @@ class LocalCommands(Commands):
                 'celery', '--app', 'invenio_app.celery', 'worker',
                 '--beat', '--events', '--loglevel', 'INFO',
             )
-            worker = popen(command)
+            worker = Popen(command)
 
         click.secho("Starting up local (development) server...", fg='green')
         run_env = environ.copy()
@@ -139,7 +139,7 @@ class LocalCommands(Commands):
             '--host', host,
             '--port', port
         )
-        server = popen(command, env=run_env)
+        server = Popen(command, env=run_env)
 
         click.secho(
             f'Instance running!\nVisit https://{host}:{port}',

--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -10,11 +10,10 @@
 
 import re
 import sys
-from os import listdir
 
 from ..commands import Commands
 from ..helpers.packaging import get_packaging_backend
-from ..helpers.process import ProcessResponse, run_cmd, run_interactive
+from ..helpers.process import ProcessResponse, run_cmd
 from .steps import FunctionStep
 
 

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -50,7 +50,7 @@ class ServicesCommands(Commands):
             )
 
         return ProcessResponse(
-                output=f"Services setup status consistent.",
+                output="Services setup status consistent.",
                 status_code=0
             )
 
@@ -85,7 +85,8 @@ class ServicesCommands(Commands):
                 message="Purging queues...",
                 skippable=True
             ),
-            FunctionStep(func=self.cli_config.update_services_setup,
+            FunctionStep(
+                func=self.cli_config.update_services_setup,
                 args={"is_setup": False},
                 message="Updating service setup status (False)..."
             )

--- a/invenio_cli/commands/services_health.py
+++ b/invenio_cli/commands/services_health.py
@@ -27,33 +27,24 @@ class ServicesHealthCommands(object):
     """Services status commands."""
 
     @classmethod
-    def es_healthcheck(cls, *args, **kwargs):
+    def es_healthcheck(cls, *args, verbose, **kwargs):
         """Elasticsearch healthcheck."""
-        verbose = kwargs['verbose']
-
         return run_cmd([
             "curl", "-f",
             "localhost:9200/_cluster/health?wait_for_status=yellow"
         ])
 
     @classmethod
-    def postgresql_healthcheck(cls, *args, **kwargs):
+    def postgresql_healthcheck(cls, *args, verbose, filepath, **kwargs):
         """Postgresql healthcheck."""
-        filepath = kwargs['filepath']
-        verbose = kwargs['verbose']
-
         return run_cmd([
             "docker-compose", "--file", filepath,
             "exec", "-T", "db", "bash", "-c", "pg_isready",
         ])
 
     @classmethod
-    def mysql_healthcheck(cls, *args, **kwargs):
+    def mysql_healthcheck(cls, *args, verbose, filepath, password, **kwargs):
         """Mysql healthcheck."""
-        filepath = kwargs['filepath']
-        verbose = kwargs['verbose']
-        password = kwargs['project_shortname']
-
         return run_cmd([
             "docker-compose", "--file", filepath,
             "exec", "-T", "db", "bash", "-c",
@@ -61,11 +52,8 @@ class ServicesHealthCommands(object):
         ])
 
     @classmethod
-    def redis_healthcheck(cls, *args, **kwargs):
+    def redis_healthcheck(cls, *args, verbose, filepath, **kwargs):
         """Redis healthcheck."""
-        filepath = kwargs['filepath']
-        verbose = kwargs['verbose']
-
         return run_cmd([
             "docker-compose", "--file", filepath,
             "exec", "-T", "cache", "bash", "-c",

--- a/invenio_cli/commands/upgrade.py
+++ b/invenio_cli/commands/upgrade.py
@@ -7,14 +7,15 @@
 
 """Invenio module to ease the creation and management of applications."""
 
+from ..helpers.packaging import get_packaging_backend
+from .commands import Commands
 from .steps import CommandStep
 
 
-class UpgradeCommands(object):
+class UpgradeCommands(Commands):
     """Local installation commands."""
 
-    @staticmethod
-    def upgrade(script_path):
+    def upgrade(self, script_path):
         """Steps to perform an upgrade of the invenio instance.
 
         First, and alembic upgrade is launched to allow alembic to migrate the
@@ -23,7 +24,7 @@ class UpgradeCommands(object):
         Last, the Elasticsearch indexes are destroyed, initialized and rebuilt.
         It is a class method since it does not require any configuration.
         """
-        prefix = ['pipenv', 'run', 'invenio']
+        prefix = get_packaging_backend(self.cli_command).run_command("invenio")
         alembic_cmd = prefix + ['alembic', 'upgrade']
         destroy_index_cmd = prefix + ['index', 'destroy', '--yes-i-know']
         init_index_cmd = prefix + ['index', 'init']

--- a/invenio_cli/helpers/__init__.py
+++ b/invenio_cli/helpers/__init__.py
@@ -13,3 +13,10 @@ from .cookiecutter_wrapper import CookiecutterWrapper
 from .docker_helper import DockerHelper
 from .env import env
 from .filesystem import get_created_files
+
+__all__ = (
+    "CookiecutterWrapper",
+    "DockerHelper",
+    "env",
+    "get_created_files",
+)

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -125,6 +125,12 @@ class CLIConfig(object):
         """Returns the file storage (local, s3, etc.)."""
         return self.config[CLIConfig.COOKIECUTTER_SECTION]['file_storage']
 
+    def get_packaging_backend(self):
+        """Return the configured packaging backend (poetry/pipenv)."""
+        return self.config[CLIConfig.COOKIECUTTER_SECTION].get(
+            'packaging_backend', 'pipenv'
+        )
+
     @classmethod
     def _write_private_config(cls, project_dir):
         """Write per-instance config file."""

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -57,7 +57,7 @@ class CLIConfig(object):
         try:
             with open(self.private_config_path) as cfg_file:
                 self.private_config.read_file(cfg_file)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             CLIConfig._write_private_config(Path(project_dir))
             with open(self.private_config_path) as cfg_file:
                 self.private_config.read_file(cfg_file)

--- a/invenio_cli/helpers/packaging.py
+++ b/invenio_cli/helpers/packaging.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Wrappers for packaging tools."""
+
+from abc import ABC, abstractmethod
+
+
+class PackagingBackend(ABC):
+    """Base wrapper for packaging tools."""
+
+    bin_name = None
+
+    def run_command(self, *args):
+        """Get the command for running a command inside the venv."""
+        return [self.bin_name, "run", *args]
+
+    def shell_command(self):
+        """Get the command for activating the venv."""
+        return [self.bin_name, "shell"]
+
+    def update_command(self):
+        """Get the command for updating the locked packages."""
+        return [self.bin_name, "update"]
+
+    @abstractmethod
+    def outdated_packages_command(self):
+        """Get the command to look up outdated packages."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def add_package_command(self, *args, pre_release=False):
+        """Get the command for installing a new package."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def lock_dependencies_command(self, dev_packages, pre_releases):
+        """Get the command for locking the packages."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def install_dependencies_command(self, dev_packages):
+        """Get the command for installing the locked packages."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def remove_venv_command(self):
+        """Get the command for removing the created venv."""
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def lock_file_name(self):
+        """Get the name of the lock file."""
+        raise NotImplementedError()
+
+
+class PipenvBackend(PackagingBackend):
+    """Pipenv packaging backend."""
+
+    bin_name = "pipenv"
+
+    def outdated_packages_command(self):
+        """Get the command to look up outdated packages."""
+        return [self.bin_name, "update", "--outdated"]
+
+    def add_package_command(self, *args, pre_release=False):
+        """Get the command for installing a new package."""
+        cmd = [self.bin_name, "install"]
+        if pre_release:
+            cmd += ["--pre"]
+
+        return [*cmd, *args]
+
+    def lock_dependencies_command(self, dev_packages, pre_releases):
+        """Get the command for locking the packages."""
+        cmd = [self.bin_name, "lock"]
+        if dev_packages:
+            cmd += ["--dev"]
+        if pre_releases:
+            cmd += ["--pre"]
+
+        return cmd
+
+    def install_dependencies_command(self, dev_packages):
+        """Get the command for installing the locked packages."""
+        cmd = [self.bin_name, "install"]
+        if dev_packages:
+            cmd += ["--dev"]
+
+        return cmd
+
+    def remove_venv_command(self):
+        """Get the command for removing the created venv."""
+        return [self.bin_name, "--rm"]
+
+    @property
+    def lock_file_name(self):
+        """Get the name of the lock file."""
+        return "Pipfile.lock"
+
+
+class PoetryBackend(PackagingBackend):
+    """Poetry packaging backend."""
+
+    bin_name = "poetry"
+
+    def outdated_packages_command(self):
+        """Get the command to look up outdated packages."""
+        return [self.bin_name, "show", "--outdated"]
+
+    def add_package_command(self, *args, pre_release=False):
+        """Get the command for installing a new package."""
+        cmd = [self.bin_name, "add"]
+        if pre_release:
+            cmd += ["--allow-prereleases"]
+
+        return [*cmd, *args]
+
+    def lock_dependencies_command(self, dev_packages, pre_releases):
+        """Get the command for locking the packages."""
+        # it seems that `poetry lock` doesn't accept `--dev` or `--pre` flags
+        # TODO verify!
+        return [self.bin_name, "lock"]
+
+    def install_dependencies_command(self, dev_packages):
+        """Get the command for installing the locked packages."""
+        cmd = [self.bin_name, "install"]
+        if not dev_packages:
+            # NOTE: this is being deprecated in poetry 1.2.x
+            cmd += ["--no-dev"]
+
+        return cmd
+
+    def remove_venv_command(self):
+        """Get the command for removing the created venv."""
+        return [self.bin_name, "env", "remove", "--all", "--quiet"]
+
+    @property
+    def lock_file_name(self):
+        """Get the name of the lock file."""
+        return "poetry.lock"
+
+
+def get_packaging_backend(config):
+    """Get the packaging backend specified in the given configuration.
+
+    If no configuration is specified, or if it has an invalid value
+    configured, the ``PipenvBackend`` will be returned as a fallback.
+    """
+    if config is not None:
+        backend_name = config.get_packaging_backend()
+        if backend_name.lower() == "poetry":
+            return PoetryBackend()
+        elif backend_name.lower() == "pipenv":
+            return PipenvBackend()
+
+    # the default value is pipenv, as that's been used so far
+    return PipenvBackend()

--- a/invenio_cli/helpers/process.py
+++ b/invenio_cli/helpers/process.py
@@ -10,9 +10,7 @@
 """Invenio CLI Process helper module."""
 
 from os import environ
-from subprocess import PIPE, CalledProcessError
-from subprocess import Popen as popen
-from subprocess import run
+from subprocess import PIPE, CalledProcessError, Popen, run
 
 
 class ProcessResponse():
@@ -31,7 +29,7 @@ class ProcessResponse():
 
 def run_cmd(command):
     """Runs a given command and returns a ProcessResponse."""
-    p = popen(command, stdout=PIPE, stderr=PIPE)
+    p = Popen(command, stdout=PIPE, stderr=PIPE)
     output, error = p.communicate()
     output = output.decode("utf-8")
     error = error.decode("utf-8")
@@ -52,9 +50,10 @@ def run_interactive(command, env=None, skippable=False):
             full_env[var] = val
 
     try:
-        response = run(command, check=True, env=full_env)
+        run(command, check=True, env=full_env)
         return ProcessResponse(
-            output=None, error=None, status_code=0)
+            output=None, error=None, status_code=0
+        )
     except CalledProcessError as e:
         if skippable:
             return ProcessResponse(


### PR DESCRIPTION
`pipenv` has a history of... being difficult at times.`poetry` is the newish kid on the block, and looks quite promising.
I've had scenarios where `poetry` was able to lock the dependencies within seconds or minutes, while `pipenv` couldn't come up with any results in an hour.
As such, it would be nice to have the option to work with `poetry` rather than `pipenv` (if you know what you're doing).

This PR adds support for `poetry` for most of the operations as an alternative packaging tool.
One known issue in `invenio-cli` is that `poetry show --outdated` will always exit with a status code of `0`, and thus `invenio-cli` will always report that all packages are up to date (even though the previous output clearly suggested the opposite).
Further, the handling of pre-release package versions is different between `pipenv` and `poetry`: It seems that `poetry` only accepts an `--allow-prereleases` flag when installing additional packages, but neither on locking nor installing dependencies from the lock file (which I feel makes sense).
Another notable difference is that `poetry` does not, by itself, read the environment variables from a `.env` file. This would have to be done in code, likely via [`python-dotenv`](https://pypi.org/project/python-dotenv/) before executing `poetry` commands.

**Note:** By default, `invenio-cli` will still use `pipenv`.
The configuration (`[cookiecutter]`) has to request `packaging_backend = poetry` specifically to switch to `poetry`.