### PR TITLE
services: add custom fields init to setup

### DIFF
--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -164,6 +164,30 @@ class ServicesCommands(Commands):
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating indices...",
             ),
+            CommandStep(
+                cmd=[
+                    "pipenv",
+                    "run",
+                    "invenio",
+                    "rdm-records",
+                    "custom-fields",
+                    "init",
+                ],
+                env={"PIPENV_VERBOSITY": "-1"},
+                message="Creating custom fields for records...",
+            ),
+            CommandStep(
+                cmd=[
+                    "pipenv",
+                    "run",
+                    "invenio",
+                    "communities",
+                    "custom-fields",
+                    "init",
+                ],
+                env={"PIPENV_VERBOSITY": "-1"},
+                message="Creating custom fields for communities...",
+            ),
             FunctionStep(
                 func=self.cli_config.update_services_setup,
                 args={"is_setup": True},


### PR DESCRIPTION
- closes #305 

Shell output:

```
Putting templates...
  [####################################]  100%
Creating custom fields for records...
Creating custom fields...
Created all custom fields!
Creating custom fields for communities...
No custom fields were configured. Exiting...
Updating service setup status (True)...
```

Since no CF were configured for communities it only did it for records. Checked with postman and the field is in the mapping.

Since the field is not `required` the demo records were created without a problem.