### PR TITLE
services: fix wait for services to start

### DIFF
--- a/invenio_cli/cli/assets.py
+++ b/invenio_cli/cli/assets.py
@@ -9,7 +9,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 import click
-from click_default_group import DefaultGroup
 
 from ..commands import AssetsCommands
 from .utils import pass_cli_config, run_steps

--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -19,6 +19,7 @@ from ..commands import (
     ContainersCommands,
     LocalCommands,
     RequirementsCommands,
+    ServicesCommands,
     UpgradeCommands,
 )
 from ..helpers.cli_config import CLIConfig
@@ -28,7 +29,7 @@ from .containers import containers
 from .install import install
 from .packages import packages
 from .services import services
-from .utils import pass_cli_config, run_steps
+from .utils import handle_process_response, pass_cli_config, run_steps
 
 
 @click.group()
@@ -167,6 +168,12 @@ def run(cli_config, host, port, debug, services, celery_log_file):
 
     NOTE: this only makes sense locally so no --local option
     """
+    if services:
+        cmds = ServicesCommands(cli_config)
+        response = cmds.ensure_containers_running()
+        # fail and exit if containers are not running
+        handle_process_response(response)
+
     commands = LocalCommands(cli_config)
     commands.run(
         host=host,

--- a/invenio_cli/cli/containers.py
+++ b/invenio_cli/cli/containers.py
@@ -11,6 +11,7 @@
 import click
 
 from ..commands import ContainersCommands
+from .services import status as services_status_cmd
 from .utils import pass_cli_config, run_steps
 
 
@@ -90,7 +91,6 @@ def setup(cli_config, force, no_demo_data, stop_services, services):
     run_steps(steps, on_fail, on_success)
 
 
-# FIXME: Duplicated code from services.py
 @containers.command()
 @click.option(
     "-v",
@@ -100,27 +100,13 @@ def setup(cli_config, force, no_demo_data, stop_services, services):
     required=False,
     help="Verbose mode will show all logs in the console.",
 )
-@pass_cli_config
-def status(cli_config, verbose):
+@click.pass_context
+def status(ctx, verbose):
     """Checks if the services are up and running.
 
     NOTE: currently only search, DB (postgresql/mysql) and redis are supported.
     """
-    commands = ContainersCommands(cli_config)
-    services = ["redis", cli_config.get_db_type(), "search"]
-    statuses = commands.status(services=services, verbose=verbose)
-
-    messages = [
-        {"message": "{}: up and running.", "fg": "green"},
-        {"message": "{}: unable to connect or bad response.", "fg": "red"},
-        {"message": "{}: no healthcheck function defined.", "fg": "yellow"},
-    ]
-
-    for idx, status in enumerate(statuses):
-        message = messages[status]
-        click.secho(
-            message=message.get("message").format(services[idx]), fg=message.get("fg")
-        )
+    ctx.invoke(services_status_cmd, verbose=verbose)
 
 
 @containers.command()

--- a/invenio_cli/cli/services.py
+++ b/invenio_cli/cli/services.py
@@ -10,7 +10,7 @@
 
 import click
 
-from ..commands import Commands, ServicesCommands
+from ..commands import ServicesCommands
 from .utils import pass_cli_config, run_steps
 
 
@@ -70,7 +70,6 @@ def setup(cli_config, force, no_demo_data, stop_services, services):
     run_steps(steps, on_fail, on_success)
 
 
-# FIXME: Duplicated code from containers.py
 @services.command()
 @click.option(
     "-v",
@@ -90,16 +89,19 @@ def status(cli_config, verbose):
     services = ["redis", cli_config.get_db_type(), "search"]
     statuses = commands.status(services=services, verbose=verbose)
 
-    messages = [
-        {"message": "{}: up and running.", "fg": "green"},
-        {"message": "{}: unable to connect or bad response.", "fg": "red"},
-        {"message": "{}: no healthcheck function defined.", "fg": "yellow"},
-    ]
+    messages = {
+        0: {"message": "{}: up and running.", "fg": "green"},
+        1: {"message": "{}: unable to connect or bad response.", "fg": "red"},
+        None: {
+            "message": "{}: no healthcheck function defined or unknown service.",
+            "fg": "yellow",
+        },
+    }
 
-    for idx, status in enumerate(statuses):
-        message = messages[status]
+    for service, status_code in statuses:
+        message = messages[status_code]
         click.secho(
-            message=message.get("message").format(services[idx]), fg=message.get("fg")
+            message=message.get("message").format(service), fg=message.get("fg")
         )
 
 

--- a/invenio_cli/cli/utils.py
+++ b/invenio_cli/cli/utils.py
@@ -18,23 +18,36 @@ def run_steps(steps, fail_message, success_message):
     """Run a series of steps."""
     for step in steps:
         click.secho(message=step.message, fg="green")
-        result = step.execute()
-        if result.status_code > 0:
-            if result.error:
-                fail_message = fail_message + f"\nErrors: {result.error}"
-            if result.output:
-                fail_message = fail_message + f"\nOutput: {result.output}"
-
-            click.secho(fail_message, fg="red")
-            exit(1)
-        elif result.warning:
-            if result.error:
-                fail_message = fail_message + f"\nErrors: {result.error}"
-            if result.output:
-                fail_message = fail_message + f"\nOutput: {result.output}"
-
-            click.secho(fail_message, fg="yellow")
-        elif result.output:
-            click.secho(message=result.output, fg="green")
+        response = step.execute()
+        handle_process_response(response, fail_message=fail_message)
     else:
         click.secho(message=success_message, fg="green")
+
+
+def handle_process_response(response, fail_message=None):
+    """Handle the `ProcessResponse` obj after cmd execution."""
+    msg = ""
+    is_error = response.status_code > 0
+    if is_error:
+        if response.error:
+            msg = f"Errors: {response.error}"
+        if response.output:
+            msg = f"Output: {response.output}"
+
+        if fail_message:
+            msg = fail_message + "\n" + msg
+
+        click.secho(msg, fg="red")
+        exit(1)
+    elif response.warning:
+        if response.error:
+            msg = f"Errors: {response.error}"
+        if response.output:
+            msg = f"Output: {response.output}"
+
+        if fail_message:
+            msg = fail_message + "\n" + msg
+
+        click.secho(msg, fg="yellow")
+    elif response.output:
+        click.secho(message=response.output, fg="green")

--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -9,7 +9,6 @@
 
 
 import subprocess
-from functools import partial
 from pathlib import Path
 
 import click
@@ -18,7 +17,7 @@ from pynpm import NPMPackage
 from ..helpers import env
 from ..helpers.process import ProcessResponse, run_interactive
 from .local import LocalCommands
-from .steps import CommandStep, FunctionStep
+from .steps import FunctionStep
 
 
 class AssetsCommands(LocalCommands):
@@ -26,7 +25,7 @@ class AssetsCommands(LocalCommands):
 
     def __init__(self, cli_config):
         """Constructor."""
-        super(AssetsCommands, self).__init__(cli_config)
+        super().__init__(cli_config)
 
     @staticmethod
     def _module_pkg(path):

--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -10,7 +10,6 @@
 from ..helpers.docker_helper import DockerHelper
 from .packages import PackagesCommands
 from .services import ServicesCommands
-from .services_health import HEALTHCHECKS
 from .steps import FunctionStep
 
 
@@ -23,7 +22,7 @@ class ContainersCommands(ServicesCommands):
             cli_config.get_project_shortname(), local=False
         )
 
-        super(ContainersCommands, self).__init__(cli_config, docker_helper)
+        super().__init__(cli_config, docker_helper)
 
     def build(self, pull=True, cache=True):
         """Return the steps to build images.

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -19,7 +19,7 @@ class InstallCommands(LocalCommands):
 
     def __init__(self, cli_config):
         """Constructor."""
-        super(InstallCommands, self).__init__(cli_config)
+        super().__init__(cli_config)
 
     def install_py_dependencies(self, pre, dev=False):
         """Install Python dependencies."""

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -19,7 +19,6 @@ import click
 from ..helpers import env, filesystem
 from ..helpers.process import ProcessResponse, run_interactive
 from .commands import Commands
-from .services import ServicesCommands
 
 
 class LocalCommands(Commands):
@@ -27,7 +26,7 @@ class LocalCommands(Commands):
 
     def __init__(self, cli_config):
         """Constructor."""
-        super(LocalCommands, self).__init__(cli_config)
+        super().__init__(cli_config)
 
     def _symlink_assets_templates(self, files_to_link):
         """Symlink the assets folder."""
@@ -126,8 +125,6 @@ class LocalCommands(Commands):
         signal.signal(signal.SIGINT, signal_handler)
 
         if services:
-            ServicesCommands(self.cli_config).ensure_containers_running()
-
             click.secho("Starting celery worker...", fg="green")
 
             celery_command = [

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -23,7 +23,7 @@ class DockerHelper(object):
 
     def __init__(self, project_shortname, local=True, log_config=None):
         """Constructor."""
-        super(DockerHelper, self).__init__()
+        super().__init__()
         self.container_prefix = self._normalize_name(project_shortname)
         self.local = local
         self.docker_client = docker.from_env()

--- a/invenio_cli/helpers/process.py
+++ b/invenio_cli/helpers/process.py
@@ -22,7 +22,7 @@ class ProcessResponse:
     def __init__(self, output=None, error=None, status_code=0, warning=False):
         """Constructor.
 
-        By default it is a successful response (0) wiht no error nor ouput.
+        By default, it is a successful response (0) with no error nor output.
         """
         self.output = output
         self.error = error


### PR DESCRIPTION
The `click` context is injected in many places (e.g. `click.echo`) but it should instead be only used in the `cli` module, not in `commands` module. With current code, is quite easy to end up with circular imports and it is not easy to make the code testable.
Tip: avoid global context (`import click`) as much as possible where it is not needed.

Some funcs are aware of how they are called: they should not be. A func should have a clear API and the caller needs to take care of the response and take actions depending on the response.