### PR TITLE
global: add support for translation commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright (C) 2019-2021 CERN.
+    Copyright (C) 2019-2022 CERN.
     Copyright (C) 2019-2021 Northwestern University.
 
     Invenio-Cli is free software; you can redistribute it and/or modify
@@ -7,6 +7,10 @@
 
 Changes
 =======
+
+Version 1.0.12 (released 2022-10-28)
+
+- Adds support for translations (i18n) management commands.
 
 Version 1.0.11 (released 2022-10-24)
 

--- a/invenio_cli/__init__.py
+++ b/invenio_cli/__init__.py
@@ -9,6 +9,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 
-__version__ = "1.0.11"
+__version__ = "1.0.12"
 
 __all__ = ("__version__",)

--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -29,6 +29,7 @@ from .containers import containers
 from .install import install
 from .packages import packages
 from .services import services
+from .translations import translations
 from .utils import handle_process_response, pass_cli_config, run_steps
 
 
@@ -44,6 +45,7 @@ invenio_cli.add_command(containers)
 invenio_cli.add_command(install)
 invenio_cli.add_command(packages)
 invenio_cli.add_command(services)
+invenio_cli.add_command(translations)
 
 
 @invenio_cli.command("check-requirements")

--- a/invenio_cli/cli/translations.py
+++ b/invenio_cli/cli/translations.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio module to ease the creation and management of applications."""
+
+from pathlib import Path
+
+import click
+
+from ..commands import TranslationsCommands
+from .utils import pass_cli_config, run_steps
+
+
+@click.group()
+def translations():
+    """Commands for translations management."""
+
+
+@translations.command()
+@click.option(
+    "--babel-ini",
+    "-b",
+    default="translations/babel.ini",
+    help="Relative path to babel.ini (including filename).",
+)
+@pass_cli_config
+def extract(cli_config, babel_ini):
+    """Extract messages for i18n support (translations)."""
+    click.secho("Extracting messages...", fg="green")
+    steps = TranslationsCommands.extract(
+        msgid_bugs_address=cli_config.get_author_email(),
+        copyright_holder=cli_config.get_author_name(),
+        babel_file=cli_config.get_project_dir() / Path("translations/babel.ini"),
+        output_file=cli_config.get_project_dir() / Path("translations/messages.pot"),
+        input_dirs=cli_config.get_project_dir(),
+    )
+    on_fail = "Failed to extract messages."
+    on_success = "Messages extracted successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
+@translations.command()
+@click.option("--locale", "-l", required=True, help="Locale to initialize.")
+@pass_cli_config
+def init(cli_config, locale):
+    """Initialized message catalog for a given locale."""
+    click.secho("Initializing messages catalog...", fg="green")
+    steps = TranslationsCommands.init(
+        output_dir=cli_config.get_project_dir() / Path("translations/"),
+        input_file=cli_config.get_project_dir() / Path("translations/messages.pot"),
+        locale=locale,
+    )
+    on_fail = f"Failed to initialize message catalog for {locale}."
+    on_success = f"Message catalog for {locale} initialized successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
+@translations.command()
+@pass_cli_config
+def update(cli_config):
+    """Update messages catalog."""
+    click.secho("Updating messages catalog...", fg="green")
+    steps = TranslationsCommands.update(
+        output_dir=cli_config.get_project_dir() / Path("translations/"),
+        input_file=cli_config.get_project_dir() / Path("translations/messages.pot"),
+    )
+    on_fail = f"Failed to update message catalog."
+    on_success = f"Message catalog updated successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
+@translations.command()
+@click.option("--fuzzy", "-f", default=True, is_flag=True, help="Use fuzzyness.")
+@pass_cli_config
+def compile(cli_config, fuzzy):
+    """Compile message catalog."""
+    click.secho("Compiling catalog...", fg="green")
+    commands = TranslationsCommands(
+        project_path=cli_config.get_project_dir(),
+        instance_path=cli_config.get_instance_path(),
+    )
+    steps = commands.compile(fuzzy=fuzzy)
+    on_fail = "Failed to compile catalog."
+    on_success = "Catalog compiled successfully."
+
+    run_steps(steps, on_fail, on_success)

--- a/invenio_cli/commands/__init__.py
+++ b/invenio_cli/commands/__init__.py
@@ -15,6 +15,7 @@ from .local import LocalCommands
 from .packages import PackagesCommands
 from .requirements import RequirementsCommands
 from .services import ServicesCommands
+from .translations import TranslationsCommands
 from .upgrade import UpgradeCommands
 
 __all__ = (
@@ -26,5 +27,6 @@ __all__ = (
     "PackagesCommands",
     "RequirementsCommands",
     "ServicesCommands",
+    "TranslationsCommands",
     "UpgradeCommands",
 )

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -10,6 +10,8 @@
 
 import click
 
+from invenio_cli.commands.translations import TranslationsCommands
+
 from ..helpers.docker_helper import DockerHelper
 from ..helpers.process import ProcessResponse
 from ..helpers.rdm import rdm_version
@@ -214,6 +216,10 @@ class ServicesCommands(Commands):
                 ]
             )
 
+        if rdm_version()[0] >= 11:
+            steps.extend(self.static_pages())
+            steps.extend(self.translations())
+
         steps.append(
             FunctionStep(
                 func=self.cli_config.update_services_setup,
@@ -262,6 +268,14 @@ class ServicesCommands(Commands):
 
         return steps
 
+    def translations(self):
+        """Steps to compile translations."""
+        commands = TranslationsCommands(
+            project_path=self.cli_config.get_project_dir(),
+            instance_path=self.cli_config.get_instance_path(),
+        )
+        return [commands.compile(symlink=False)[0]]
+
     def setup(self, force, demo_data=True, stop=False, services=True):
         """Steps to setup services' containers.
 
@@ -282,8 +296,6 @@ class ServicesCommands(Commands):
 
         steps.extend(self._setup())
         steps.extend(self.fixtures())
-        if rdm_version()[0] >= 11:
-            steps.extend(self.static_pages())
 
         if demo_data:
             steps.extend(self.demo())

--- a/invenio_cli/commands/translations.py
+++ b/invenio_cli/commands/translations.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio module to ease the creation and management of applications."""
+
+from pathlib import Path
+
+from ..commands import Commands
+from ..helpers.filesystem import force_symlink
+from .steps import CommandStep, FunctionStep
+
+
+class TranslationsCommands(Commands):
+    """Translations CLI commands."""
+
+    CMD_PREFIX = ["pipenv", "run"]
+
+    def __init__(self, project_path, instance_path):
+        """Constructor."""
+        self.project_path = project_path
+        self.instance_path = instance_path
+
+    @classmethod
+    def extract(
+        cls,
+        babel_file,
+        output_file,
+        input_dirs,
+        msgid_bugs_address,
+        copyright_holder,
+        add_comments="NOTE",
+    ):
+        """Extract messages from source code and templates."""
+        cmd = cls.CMD_PREFIX + [
+            "pybabel",
+            "extract",
+            f"--mapping-file={babel_file}",
+            f"--output-file={output_file}",
+            f"--input-dirs={input_dirs}",
+            f"--msgid-bugs-address={msgid_bugs_address}",
+            f"--copyright-holder={copyright_holder}",
+            f"--add-comments={add_comments}",
+        ]
+
+        return [
+            CommandStep(
+                cmd=cmd,
+                env={"PIPENV_VERBOSITY": "-1"},
+                message=f"Extracting i18n messages from {input_dirs}...",
+            )
+        ]
+
+    @classmethod
+    def init(cls, output_dir, input_file, locale):
+        """Initialize a new language catalog."""
+        cmd = cls.CMD_PREFIX + [
+            "pybabel",
+            "init",
+            f"--output-dir={output_dir}",
+            f"--input-file={input_file}",
+            f"--locale={locale}",
+        ]
+
+        return [
+            CommandStep(
+                cmd=cmd,
+                env={"PIPENV_VERBOSITY": "-1"},
+                message=f"Initializing message catalog for {locale}...",
+            )
+        ]
+
+    @classmethod
+    def update(cls, output_dir, input_file):
+        """Update the message catalog."""
+        cmd = cls.CMD_PREFIX + [
+            "pybabel",
+            "update",
+            f"--output-dir={output_dir}",
+            f"--input-file={input_file}",
+        ]
+
+        return [
+            CommandStep(
+                cmd=cmd,
+                env={"PIPENV_VERBOSITY": "-1"},
+                message=f"Updating message catalog...",
+            )
+        ]
+
+    def compile(
+        self,
+        directory=None,
+        fuzzy=False,
+        translation_folder="translations",
+        symlink=True,
+    ):
+        """Compile the message catalog."""
+        directory = directory or self.project_path / translation_folder
+
+        cmd = self.CMD_PREFIX + [
+            "pybabel",
+            "compile",
+            f"--directory={directory}",
+        ]
+
+        if fuzzy:
+            cmd.append("--use-fuzzy")
+
+        steps = [
+            CommandStep(
+                cmd=cmd,
+                env={"PIPENV_VERBOSITY": "-1"},
+                message=f"Compiling message catalog...",
+            ),
+        ]
+
+        if symlink:
+            target_path = self.project_path / translation_folder
+            link_path = self.instance_path / translation_folder
+
+            steps.append(
+                FunctionStep(
+                    func=force_symlink,
+                    args={
+                        "target": target_path,
+                        "link_name": link_path,
+                    },
+                    message="Symlinking translations...",
+                )
+            )
+
+        return steps

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -132,6 +132,14 @@ class CLIConfig(object):
         """Returns the file storage (local, s3, etc.)."""
         return self.config[CLIConfig.COOKIECUTTER_SECTION]["file_storage"]
 
+    def get_author_email(self):
+        """Returns the email of the author/owner of the project."""
+        return self.config[CLIConfig.COOKIECUTTER_SECTION]["author_email"]
+
+    def get_author_name(self):
+        """Returns the name of the author/owner of the project."""
+        return self.config[CLIConfig.COOKIECUTTER_SECTION]["author_name"]
+
     @classmethod
     def _write_private_config(cls, project_dir):
         """Write per-instance config file."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
+    Babel>=2.8
     cookiecutter>=1.7.1,<1.8.0
     click>=7.1.1,<8.2
     click-default-group>=1.2.2,<2.0.0


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/241

In the following image you can see:

- On the top left, extracted messages both from `./site` and `invenio.cfg`
- On the bottom left the part of the `container start ...` that corresponds to the catalog compilation
- On the right, InvenioRDM running on containerized version (alsto tested local and it's the same) with a translated string being shown.

![Screenshot 2022-10-26 at 16 58 52](https://user-images.githubusercontent.com/6756943/198062153-5036df3d-dcba-43d3-a815-620761e009de.png)


**Pending**
- If the implementation is approved/merged. We should document it, since users still need to create catalogs for the desired language (that cannot be automated since we cannot know in advance which language/s the user wants).


---

@mb-wali This PR (along with one in cookiecutter) will enable users to add their own custom translations + translate strings form their cfg/custom code. Requesting your review since you are Translator master 🚀 