### PR TITLE
wip: change webpack cmds after upgrade

### DIFF
--- a/tests/commands/test_containers.py
+++ b/tests/commands/test_containers.py
@@ -31,9 +31,7 @@ def expected_setup_calls():
         call("project-shortname", "invenio index init"),
         # update_statics_and_assets call
         call("project-shortname", "invenio collect"),
-        call("project-shortname", "invenio webpack create"),
-        call("project-shortname", "invenio webpack install --unsafe"),
-        call("project-shortname", "invenio webpack build"),
+        call("project-shortname", "invenio webpack buildall"),
     ]
 
 
@@ -88,7 +86,7 @@ def test_containerize_no_install(
     commands.containerize(pre=False, force=False, install=False)
 
     assert (
-        call("project-shortname", "invenio webpack install --unsafe")
+        call("project-shortname", "invenio webpack install")
         not in commands.docker_helper.execute_cli_command.mock_calls
     )
 
@@ -155,9 +153,7 @@ def test_update_statics_and_assets(p_docker_helper, p_run_cmd, mock_cli_config):
 
     expected_execute_cli_calls = [
         call("project-shortname", "invenio collect"),
-        call("project-shortname", "invenio webpack create"),
-        call("project-shortname", "invenio webpack install --unsafe"),
-        call("project-shortname", "invenio webpack build"),
+        call("project-shortname", "invenio webpack buildall"),
     ]
     assert (
         commands.docker_helper.execute_cli_command.mock_calls

--- a/tests/commands/test_local.py
+++ b/tests/commands/test_local.py
@@ -113,9 +113,7 @@ def test_update_statics_and_assets(p_run_cmd, p_copy_tree, mock_cli_config):
 
     expected_calls = [
         call(["pipenv", "run", "invenio", "collect", "--verbose"]),
-        call(["pipenv", "run", "invenio", "webpack", "clean", "create"]),
-        call(["pipenv", "run", "invenio", "webpack", "install"]),
-        call(["pipenv", "run", "invenio", "webpack", "build"]),
+        call(["pipenv", "run", "invenio", "webpack", "clean", "buildall"]),
     ]
     assert p_run_cmd.mock_calls == expected_calls
     p_copy_tree.assert_any_call("project_dir/static", "instance_dir/static")


### PR DESCRIPTION
TO CHANGE: the new command should be run only for InvenioRDM >= v11, or we have to test it if it also works with Invenio v9 and Node 14.