### PR TITLE
fix error message on catalog compilation command

### DIFF
--- a/invenio_cli/cli/utils.py
+++ b/invenio_cli/cli/utils.py
@@ -45,9 +45,6 @@ def handle_process_response(response, fail_message=None):
         if response.output:
             msg = f"Output: {response.output}"
 
-        if fail_message:
-            msg = fail_message + "\n" + msg
-
         click.secho(msg, fg="yellow")
     elif response.output:
         click.secho(message=response.output, fg="green")

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -274,7 +274,7 @@ class ServicesCommands(Commands):
             project_path=self.cli_config.get_project_dir(),
             instance_path=self.cli_config.get_instance_path(),
         )
-        return [commands.compile(symlink=False)[0]]
+        return commands.compile(symlink=False)
 
     def setup(self, force, demo_data=True, stop=False, services=True):
         """Steps to setup services' containers.

--- a/invenio_cli/helpers/process.py
+++ b/invenio_cli/helpers/process.py
@@ -54,7 +54,7 @@ def run_interactive(command, env=None, skippable=False, log_file=None):
 
     try:
         stdout = open(log_file, "a") if log_file else None
-        response = run(command, check=True, env=full_env, stdout=stdout, stderr=stdout)
+        _ = run(command, check=True, env=full_env, stdout=stdout, stderr=stdout)
         return ProcessResponse(output=None, error=None, status_code=0)
     except CalledProcessError as e:
         if skippable:


### PR DESCRIPTION
It looks like this now:

```shell
Created required fixtures!
Compiling message catalog...
Traceback (most recent call last):
  File "/Users/ppanero/.virtualenvs/instance-comm-perm/bin/pybabel", line 8, in <module>
    sys.exit(main())
  File "/Users/ppanero/.virtualenvs/instance-comm-perm/lib/python3.9/site-packages/babel/messages/frontend.py", line 1034, in main
    return CommandLineInterface().run(sys.argv)
  File "/Users/ppanero/.virtualenvs/instance-comm-perm/lib/python3.9/site-packages/babel/messages/frontend.py", line 960, in run
    return cmdinst.run()
  File "/Users/ppanero/.virtualenvs/instance-comm-perm/lib/python3.9/site-packages/babel/messages/frontend.py", line 198, in run
    for errors in self._run_domain(domain).values():
  File "/Users/ppanero/.virtualenvs/instance-comm-perm/lib/python3.9/site-packages/babel/messages/frontend.py", line 236, in _run_domain
    raise OptionError('no message catalogs found')
distutils.errors.DistutilsOptionError: no message catalogs found

Updating service setup status (True)...
Service setup status updated (new value True).
```

**important** the fail message at the moment exists per cli-commnad, an improvement would be to have them per command-step. But this is a bigger task that should be tackled in a different issue (needs to be opened).