### PR TITLE
Services: add 'declare queues' step to setup

### DIFF
--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -169,6 +169,9 @@ class ContainersCommands(ServicesCommands):
             steps.extend(self.rdm_fixtures(project_shortname))
             steps.extend(self.translations(project_shortname))
 
+        if rdm_version()[0] >= 12:
+            steps.extend(self.declare_queues(project_shortname))
+
         return steps
 
     def demo(self, project_shortname):
@@ -184,6 +187,20 @@ class ContainersCommands(ServicesCommands):
             )
         ]
 
+        return steps
+
+    def declare_queues(self, project_shortname):
+        """Steps to declare the MQ queues required for statistics, etc."""
+        steps = [
+            FunctionStep(
+                func=self.docker_helper.execute_cli_command,
+                args={
+                    "project_shortname": project_shortname,
+                    "command": "invenio queues declare",
+                },
+                message="Declaring queues...",
+            )
+        ]
         return steps
 
     def fixtures(self, project_shortname):

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -220,6 +220,9 @@ class ServicesCommands(Commands):
             steps.extend(self.rdm_fixtures())
             steps.extend(self.translations())
 
+        if rdm_version()[0] >= 12:
+            steps.extend(self.declare_queues())
+
         steps.append(
             FunctionStep(
                 func=self.cli_config.update_services_setup,
@@ -240,6 +243,12 @@ class ServicesCommands(Commands):
             )
         ]
 
+        return steps
+
+    def declare_queues(self):
+        """Steps to declare the MQ queues required for statistics, etc."""
+        command = ["pipenv", "run", "invenio", "queues", "declare"]
+        steps = [CommandStep(cmd=command, message="Declaring queues...")]
         return steps
 
     def fixtures(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     pipenv>=2020.6.2
     PyYAML>=5.1.2
     pynpm>=0.1.2
-    virtualenv>=20.0.35,<=20.13.0
+    virtualenv>=20.0.35
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
This is required in order for the statistics integration to work properly, because it relies on messaging via a message queue.
Needs some testing.