### PR TITLE
Switch to `docker compose` v2 

### DIFF
--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -196,8 +196,8 @@ class RequirementsCommands(object):
     def check_dev(cls):
         """Steps to check the development pre-requisites."""
         if rdm_version()[0] >= 11:
-            node_version = 18
-            npm_version = 9
+            node_version = 16
+            npm_version = 7
         else:
             # for backwards compatibility with v9 (LTS)
             node_version = 14

--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2023 ULB Münster.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -113,7 +114,7 @@ class RequirementsCommands(object):
         # Output comes in the form of
         # 'Docker version 19.03.13, build 4484c46d9d\n'
         try:
-            result = run_cmd(["docker", "--version"])
+            result = run_cmd(["docker", "version"])
             version = cls._version_from_string(result.output.strip())
             return cls._check_version("Docker", version, major, minor, patch, exact)
         except Exception as err:
@@ -123,9 +124,9 @@ class RequirementsCommands(object):
     def check_docker_compose_version(cls, major, minor=-1, patch=-1, exact=False):
         """Check the docker compose version."""
         # Output comes in the form of
-        # 'docker-compose version 1.27.4, build 4484c46d9d\n'
+        # 'Docker Compose version v2.17.3\n'
         try:
-            result = run_cmd(["docker-compose", "--version"])
+            result = run_cmd(["docker", "compose", "version"])
             version = cls._version_from_string(result.output.strip())
             return cls._check_version(
                 "Docker Compose", version, major, minor, patch, exact
@@ -193,8 +194,8 @@ class RequirementsCommands(object):
     def check_dev(cls):
         """Steps to check the development pre-requisites."""
         if rdm_version()[0] >= 11:
-            node_version = 16
-            npm_version = 7
+            node_version = 18
+            npm_version = 9
         else:
             # for backwards compatibility with v9 (LTS)
             node_version = 14

--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -13,10 +13,10 @@ import re
 import sys
 from os import listdir
 
+from ..helpers.docker_helper import DockerHelper
 from ..helpers.process import ProcessResponse, run_cmd, run_interactive
 from ..helpers.rdm import rdm_version
 from .steps import FunctionStep
-from ..helpers.docker_helper import DockerHelper
 
 
 class RequirementsCommands(object):

--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -9,6 +9,7 @@
 
 """Invenio module to ease the creation and management of applications."""
 
+import json
 import re
 import sys
 from os import listdir
@@ -112,11 +113,11 @@ class RequirementsCommands(object):
     @classmethod
     def check_docker_version(cls, major, minor=-1, patch=-1, exact=False):
         """Check the docker version."""
-        # Output comes in the form of
-        # 'Docker version 19.03.13, build 4484c46d9d\n'
+        # Use JSON Formatted output and parse it
         try:
-            result = run_cmd(["docker", "version"])
-            version = cls._version_from_string(result.output.strip())
+            result = run_cmd(["docker", "version", "--format", "json"])
+            result_json = json.loads(result.output.strip())
+            version = cls._version_from_string(result_json["Client"]["Version"])
             return cls._check_version("Docker", version, major, minor, patch, exact)
         except Exception as err:
             return ProcessResponse(error=f"Docker not found. Got {err}.", status_code=1)

--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -16,6 +16,7 @@ from os import listdir
 from ..helpers.process import ProcessResponse, run_cmd, run_interactive
 from ..helpers.rdm import rdm_version
 from .steps import FunctionStep
+from ..helpers.docker_helper import DockerHelper
 
 
 class RequirementsCommands(object):
@@ -125,8 +126,9 @@ class RequirementsCommands(object):
         """Check the docker compose version."""
         # Output comes in the form of
         # 'Docker Compose version v2.17.3\n'
+        docker_helper = DockerHelper("", local=False)
         try:
-            result = run_cmd(["docker", "compose", "version"])
+            result = run_cmd(docker_helper.docker_compose + ["version"])
             version = cls._version_from_string(result.output.strip())
             return cls._check_version(
                 "Docker Compose", version, major, minor, patch, exact

--- a/invenio_cli/commands/services_health.py
+++ b/invenio_cli/commands/services_health.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2023 ULB Münster.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -41,7 +42,8 @@ class ServicesHealthCommands(object):
 
         return run_cmd(
             [
-                "docker-compose",
+                "docker",
+                "compose",
                 "--file",
                 filepath,
                 "exec",
@@ -62,7 +64,8 @@ class ServicesHealthCommands(object):
 
         return run_cmd(
             [
-                "docker-compose",
+                "docker",
+                "compose",
                 "--file",
                 filepath,
                 "exec",
@@ -82,7 +85,8 @@ class ServicesHealthCommands(object):
 
         return run_cmd(
             [
-                "docker-compose",
+                "docker",
+                "compose",
                 "--file",
                 filepath,
                 "exec",

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -25,6 +25,7 @@ class DockerHelper(object):
     def __init__(self, project_shortname, local=True, log_config=None):
         """Constructor."""
         super().__init__()
+        self.docker_compose = ["docker", "compose"]
         self.container_prefix = self._normalize_name(project_shortname)
         self.local = local
         self.docker_client = docker.from_env()
@@ -35,7 +36,7 @@ class DockerHelper(object):
         Docker-Compose introduced support for dash and underscore in
         version 1.21.0.
         """
-        dc_version_string = run_cmd(["docker", "compose", "version"])
+        dc_version_string = run_cmd(self.docker_compose + ["version"])
         groups = re.search(r"[0-9].[0-9]*.[0-9]*", dc_version_string.output)
         dc_version = groups.group(0)
 
@@ -65,9 +66,7 @@ class DockerHelper(object):
         :param pull: Adds --pull to the docker-compose command.
         :param cache: Removes --no-cache to the docker-compose command.
         """
-        command = [
-            "docker",
-            "compose",
+        command = self.docker_compose + [
             "--file",
             "docker-compose.full.yml",
             "build",
@@ -85,9 +84,7 @@ class DockerHelper(object):
 
         :param app_only: Boot up only ui and api containers.
         """
-        command = [
-            "docker",
-            "compose",
+        command = self.docker_compose + [
             "--file",
             "docker-compose.yml" if self.local else "docker-compose.full.yml",
             "up",
@@ -101,14 +98,12 @@ class DockerHelper(object):
 
     def stop_containers(self):
         """Stop currently running containers."""
-        command = ["docker", "compose", "--file", "docker-compose.full.yml", "stop"]
+        command = self.docker_compose + ["--file", "docker-compose.full.yml", "stop"]
         return run_cmd(command)
 
     def destroy_containers(self):
         """Stop and remove all containers, volumes and images."""
-        command = [
-            "docker",
-            "compose",
+        command = self.docker_compose + [
             "--file",
             "docker-compose.full.yml",
             "down",

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2019 CERN.
 # Copyright (C) 2019 Northwestern University.
+# Copyright (C) 2023 ULB Münster.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -34,7 +35,7 @@ class DockerHelper(object):
         Docker-Compose introduced support for dash and underscore in
         version 1.21.0.
         """
-        dc_version_string = run_cmd(["docker-compose", "--version"])
+        dc_version_string = run_cmd(["docker",  "compose", "version"])
         groups = re.search(r"[0-9].[0-9]*.[0-9]*", dc_version_string.output)
         dc_version = groups.group(0)
 
@@ -65,7 +66,7 @@ class DockerHelper(object):
         :param cache: Removes --no-cache to the docker-compose command.
         """
         command = [
-            "docker-compose",
+            "docker",  "compose",
             "--file",
             "docker-compose.full.yml",
             "build",
@@ -84,7 +85,7 @@ class DockerHelper(object):
         :param app_only: Boot up only ui and api containers.
         """
         command = [
-            "docker-compose",
+            "docker",  "compose",
             "--file",
             "docker-compose.yml" if self.local else "docker-compose.full.yml",
             "up",
@@ -98,13 +99,13 @@ class DockerHelper(object):
 
     def stop_containers(self):
         """Stop currently running containers."""
-        command = ["docker-compose", "--file", "docker-compose.full.yml", "stop"]
+        command = ["docker",  "compose", "--file", "docker-compose.full.yml", "stop"]
         return run_cmd(command)
 
     def destroy_containers(self):
         """Stop and remove all containers, volumes and images."""
         command = [
-            "docker-compose",
+            "docker",  "compose",
             "--file",
             "docker-compose.full.yml",
             "down",

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -35,7 +35,7 @@ class DockerHelper(object):
         Docker-Compose introduced support for dash and underscore in
         version 1.21.0.
         """
-        dc_version_string = run_cmd(["docker",  "compose", "version"])
+        dc_version_string = run_cmd(["docker", "compose", "version"])
         groups = re.search(r"[0-9].[0-9]*.[0-9]*", dc_version_string.output)
         dc_version = groups.group(0)
 
@@ -66,7 +66,8 @@ class DockerHelper(object):
         :param cache: Removes --no-cache to the docker-compose command.
         """
         command = [
-            "docker",  "compose",
+            "docker",
+            "compose",
             "--file",
             "docker-compose.full.yml",
             "build",
@@ -85,7 +86,8 @@ class DockerHelper(object):
         :param app_only: Boot up only ui and api containers.
         """
         command = [
-            "docker",  "compose",
+            "docker",
+            "compose",
             "--file",
             "docker-compose.yml" if self.local else "docker-compose.full.yml",
             "up",
@@ -99,13 +101,14 @@ class DockerHelper(object):
 
     def stop_containers(self):
         """Stop currently running containers."""
-        command = ["docker",  "compose", "--file", "docker-compose.full.yml", "stop"]
+        command = ["docker", "compose", "--file", "docker-compose.full.yml", "stop"]
         return run_cmd(command)
 
     def destroy_containers(self):
         """Stop and remove all containers, volumes and images."""
         command = [
-            "docker",  "compose",
+            "docker",
+            "compose",
             "--file",
             "docker-compose.full.yml",
             "down",

--- a/tests/helpers/test_dockerhelper.py
+++ b/tests/helpers/test_dockerhelper.py
@@ -39,5 +39,13 @@ def test_start_containers(p_run_cmd):
     docker_helper.start_containers()
 
     p_run_cmd.run.assert_called_with(
-        ["docker", "compose", "--file", "docker-compose.full.yml", "up", "--build", "-d"]
+        [
+            "docker",
+            "compose",
+            "--file",
+            "docker-compose.full.yml",
+            "up",
+            "--build",
+            "-d",
+        ]
     )

--- a/tests/helpers/test_dockerhelper.py
+++ b/tests/helpers/test_dockerhelper.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2019-2020 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C) 2023 ULB Münster.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,7 +30,7 @@ def test_start_containers(p_run_cmd):
     docker_helper.start_containers()
 
     p_run_cmd.run.assert_called_with(
-        ["docker-compose", "--file", "docker-compose.yml", "up", "--build", "-d"]
+        ["docker", "compose", "--file", "docker-compose.yml", "up", "--build", "-d"]
     )
 
     with patch.object(DockerHelper, "_normalize_name", fake_normalize_name):
@@ -38,5 +39,5 @@ def test_start_containers(p_run_cmd):
     docker_helper.start_containers()
 
     p_run_cmd.run.assert_called_with(
-        ["docker-compose", "--file", "docker-compose.full.yml", "up", "--build", "-d"]
+        ["docker", "compose", "--file", "docker-compose.full.yml", "up", "--build", "-d"]
     )

--- a/tests/helpers/test_dockerhelper.py
+++ b/tests/helpers/test_dockerhelper.py
@@ -30,7 +30,8 @@ def test_start_containers(p_run_cmd):
     docker_helper.start_containers()
 
     p_run_cmd.run.assert_called_with(
-        ["docker", "compose", "--file", "docker-compose.yml", "up", "--build", "-d"]
+        docker_helper.docker_compose
+        + ["--file", "docker-compose.yml", "up", "--build", "-d"]
     )
 
     with patch.object(DockerHelper, "_normalize_name", fake_normalize_name):


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-cli/issues/348

:heart: Thank you for your contribution!

### Description

As described in https://github.com/inveniosoftware/invenio-cli/issues/348 `invenio-cli` internally uses the deprecated version 1x of `docker-compose` to orchestrate containers. This forces users to install the old version alongside the newer version of `docker compose`. This pull request changes the underlying subcommands to use the new syntax.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
