### PR TITLE
Split `install` and `run` commands

### DIFF
--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -30,7 +30,12 @@ from .install import install
 from .packages import packages
 from .services import services
 from .translations import translations
-from .utils import handle_process_response, pass_cli_config, run_steps
+from .utils import (
+    combine_decorators,
+    handle_process_response,
+    pass_cli_config,
+    run_steps,
+)
 
 
 @click.group()
@@ -142,34 +147,42 @@ def init(flavour, template, checkout, user_input, config):
         cookiecutter_wrapper.remove_config()
 
 
-@invenio_cli.command()
-@click.option("--host", "-h", default="127.0.0.1", help="The interface to bind to.")
-@click.option("--port", "-p", default=5000, help="The port to bind to.")
-@click.option(
-    "--debug/--no-debug",
-    "-d/",
-    default=True,
-    is_flag=True,
-    help="Enable/disable debug mode including auto-reloading " "(default: enabled).",
-)
-@click.option(
+@invenio_cli.group("run", invoke_without_command=True)
+@click.pass_context
+def run_group(ctx):
+    """Run command group."""
+    # For backward compatibility
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(run_all)
+
+
+services_option = click.option(
     "--services/--no-services",
     "-s/-n",
     default=True,
     is_flag=True,
     help="Enable/disable dockerized services (default: enabled).",
 )
-@click.option(
-    "--celery-log-file",
-    default=None,
-    help="Celery log file (default: None, this means logging to stderr)",
+web_options = combine_decorators(
+    click.option("--host", "-h", default="127.0.0.1", help="The interface to bind to."),
+    click.option("--port", "-p", default=5000, help="The port to bind to."),
+    click.option(
+        "--debug/--no-debug",
+        "-d/",
+        default=True,
+        is_flag=True,
+        help="Enable/disable debug mode including auto-reloading "
+        "(default: enabled).",
+    ),
 )
-@pass_cli_config
-def run(cli_config, host, port, debug, services, celery_log_file):
-    """Starts the local development server.
 
-    NOTE: this only makes sense locally so no --local option
-    """
+
+@run_group.command("web")
+@services_option
+@web_options
+@pass_cli_config
+def run_web(cli_config, host, port, debug, services):
+    """Starts the local development web server."""
     if services:
         cmds = ServicesCommands(cli_config)
         response = cmds.ensure_containers_running()
@@ -177,13 +190,61 @@ def run(cli_config, host, port, debug, services, celery_log_file):
         handle_process_response(response)
 
     commands = LocalCommands(cli_config)
-    commands.run(
+    processes = commands.run_web(host=host, port=str(port), debug=debug)
+    for proc in processes:
+        proc.wait()
+
+
+worker_options = combine_decorators(
+    click.option(
+        "--celery-log-file",
+        default=None,
+        help="Celery log file (default: None, this means logging to stderr)",
+    ),
+)
+
+
+@run_group.command("worker")
+@services_option
+@worker_options
+@pass_cli_config
+def run_worker(cli_config, services, celery_log_file):
+    """Starts the local development server."""
+    if services:
+        cmds = ServicesCommands(cli_config)
+        response = cmds.ensure_containers_running()
+        # fail and exit if containers are not running
+        handle_process_response(response)
+
+    commands = LocalCommands(cli_config)
+    processes = commands.run_worker(celery_log_file=celery_log_file)
+    for proc in processes:
+        proc.wait()
+
+
+@run_group.command("all")
+@services_option
+@web_options
+@worker_options
+@pass_cli_config
+def run_all(cli_config, host, port, debug, services, celery_log_file):
+    """Starts web and worker development servers."""
+    if services:
+        cmds = ServicesCommands(cli_config)
+        response = cmds.ensure_containers_running()
+        # fail and exit if containers are not running
+        handle_process_response(response)
+
+    commands = LocalCommands(cli_config)
+    processes = commands.run_all(
         host=host,
         port=str(port),
         debug=debug,
         services=services,
         celery_log_file=celery_log_file,
     )
+    for proc in processes:
+        proc.wait()
 
 
 @invenio_cli.command()

--- a/invenio_cli/cli/install.py
+++ b/invenio_cli/cli/install.py
@@ -60,6 +60,51 @@ def install_all(cli_config, pre, dev, production):
     run_steps(steps, on_fail, on_success)
 
 
+@install.command("python")
+@click.option(
+    "--pre",
+    default=False,
+    is_flag=True,
+    help="If specified, allows the installation of alpha releases",
+)
+@click.option(
+    "--dev/--no-dev",
+    default=True,
+    is_flag=True,
+    help="Includes development dependencies.",
+)
+@pass_cli_config
+def install_python(cli_config, pre, dev):
+    """Install Python dependencies and packages."""
+    commands = InstallCommands(cli_config)
+    steps = commands.install_py_dependencies(pre=pre, dev=dev)
+    on_fail = "Failed to install Python dependencies."
+    on_success = "Python dependencies installed successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
+@install.command("assets")
+@click.option(
+    "--production/--development",
+    "-p/-d",
+    default=False,
+    is_flag=True,
+    help="Production mode copies statics/assets. Development mode symlinks"
+    " statics/assets.",
+)
+@pass_cli_config
+def install_assets(cli_config, production):
+    """Install assets."""
+    commands = InstallCommands(cli_config)
+    flask_env = "production" if production else "development"
+    steps = commands.install_assets(flask_env)
+    on_fail = "Failed to install assets."
+    on_success = "Assets installed successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
 @install.command()
 @pass_cli_config
 def symlink(cli_config):

--- a/invenio_cli/cli/install.py
+++ b/invenio_cli/cli/install.py
@@ -13,7 +13,16 @@ from ..commands import InstallCommands
 from .utils import pass_cli_config, run_steps
 
 
-@click.command()
+@click.group(invoke_without_command=True)
+@click.pass_context
+def install(ctx):
+    """Commands for installing the project."""
+    if ctx.invoked_subcommand is None:
+        # If no sub-command is passed, default to the install all command.
+        ctx.invoke(install_all)
+
+
+@install.command("all")
 @click.option(
     "--pre",
     default=False,
@@ -35,8 +44,8 @@ from .utils import pass_cli_config, run_steps
     " statics/assets.",
 )
 @pass_cli_config
-def install(cli_config, pre, dev, production):
-    """Installs the  project locally.
+def install_all(cli_config, pre, dev, production):
+    """Installs the project locally.
 
     Installs dependencies, creates instance directory,
     links invenio.cfg + templates, copies images and other statics and finally
@@ -47,5 +56,17 @@ def install(cli_config, pre, dev, production):
     steps = commands.install(pre=pre, dev=dev, flask_env=flask_env)
     on_fail = "Failed to install dependencies."
     on_success = "Dependencies installed successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
+@install.command()
+@pass_cli_config
+def symlink(cli_config):
+    """Symlinks project files in the instance directory."""
+    commands = InstallCommands(cli_config)
+    steps = commands.symlink()
+    on_fail = "Failed to symlink project files and folders."
+    on_success = "Project ffles and folders symlinked successfully."
 
     run_steps(steps, on_fail, on_success)

--- a/invenio_cli/cli/utils.py
+++ b/invenio_cli/cli/utils.py
@@ -48,3 +48,14 @@ def handle_process_response(response, fail_message=None):
         click.secho(msg, fg="yellow")
     elif response.output:
         click.secho(message=response.output, fg="green")
+
+
+def combine_decorators(*decorators):
+    """Combine multiple decorators."""
+
+    def _decorator(f):
+        for dec in reversed(decorators):
+            f = dec(f)
+        return f
+
+    return _decorator

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -7,11 +7,11 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-from ..helpers import env, filesystem
+from ..helpers import filesystem
 from ..helpers.process import run_cmd
 from .local import LocalCommands
 from .packages import PackagesCommands
-from .steps import CommandStep, FunctionStep
+from .steps import FunctionStep
 
 
 class InstallCommands(LocalCommands):
@@ -54,12 +54,31 @@ class InstallCommands(LocalCommands):
             result.output = "Instance path updated successfully."
         return result
 
-    def symlink_project_file_or_folder(self, target):
+    def _symlink_project_file_or_folder(self, target):
         """Create symlink in instance pointing to project file or folder."""
         target_path = self.cli_config.get_project_dir() / target
         link_path = self.cli_config.get_instance_path() / target
 
         return filesystem.force_symlink(target_path, link_path)
+
+    def symlink(self):
+        """Sylink all necessary project files and folders."""
+        steps = []
+        steps.append(
+            FunctionStep(
+                func=self.update_instance_path, message="Updating instance path..."
+            )
+        )
+        steps.extend([
+            FunctionStep(
+                func=self._symlink_project_file_or_folder,
+                args={"target": path},
+                message=f"Symlinking '{path}'...",
+            )
+            for path in ("invenio.cfg", "templates", "app_data")
+        ])
+        return steps
+
 
     def install(self, pre, dev=False, flask_env="production"):
         """Development installation steps."""
@@ -69,27 +88,7 @@ class InstallCommands(LocalCommands):
                 func=self.update_instance_path, message="Updating instance path..."
             )
         )
-        steps.append(
-            FunctionStep(
-                func=self.symlink_project_file_or_folder,
-                args={"target": "invenio.cfg"},
-                message=f"Symlinking 'invenio.cfg'...",
-            )
-        )
-        steps.append(
-            FunctionStep(
-                func=self.symlink_project_file_or_folder,
-                args={"target": "templates"},
-                message=f"Symlinking 'templates'...",
-            )
-        )
-        steps.append(
-            FunctionStep(
-                func=self.symlink_project_file_or_folder,
-                args={"target": "app_data"},
-                message=f"Symlinking 'app_data'...",
-            )
-        )
+        steps.extend(self.symlink())
         steps.append(
             FunctionStep(
                 func=self.update_statics_and_assets,

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -69,16 +69,29 @@ class InstallCommands(LocalCommands):
                 func=self.update_instance_path, message="Updating instance path..."
             )
         )
-        steps.extend([
-            FunctionStep(
-                func=self._symlink_project_file_or_folder,
-                args={"target": path},
-                message=f"Symlinking '{path}'...",
-            )
-            for path in ("invenio.cfg", "templates", "app_data")
-        ])
+
+        paths = ("invenio.cfg", "templates", "app_data")
+        steps.extend(
+            [
+                FunctionStep(
+                    func=self._symlink_project_file_or_folder,
+                    args={"target": path},
+                    message=f"Symlinking '{path}'...",
+                )
+                for path in paths
+            ]
+        )
         return steps
 
+    def install_assets(self, flask_env="production"):
+        """Install assets."""
+        return [
+            FunctionStep(
+                func=self.update_statics_and_assets,
+                args={"force": True, "flask_env": flask_env},
+                message="Updating statics and assets...",
+            )
+        ]
 
     def install(self, pre, dev=False, flask_env="production"):
         """Development installation steps."""
@@ -89,12 +102,6 @@ class InstallCommands(LocalCommands):
             )
         )
         steps.extend(self.symlink())
-        steps.append(
-            FunctionStep(
-                func=self.update_statics_and_assets,
-                args={"force": True, "flask_env": flask_env},
-                message="Updating statics and assets...",
-            )
-        )
+        steps.extend(self.install_assets(flask_env))
 
         return steps

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -141,6 +141,8 @@ class LocalCommands(Commands):
                 "--events",
                 "--loglevel",
                 "INFO",
+                "--queues",
+                "celery,low",
             ]
 
             if celery_log_file:


### PR DESCRIPTION
* Split `install` command to `install {symlink,python,assets,all}`.
* Split `run` command to `run {web,worker,all}`.
* Explicitly makes the Celery worker listen to the "default" and "low" queues.
