### PR TITLE
Worker process should also be waited

### DIFF
--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2024 University Politehnica of Bucharest
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -178,3 +179,7 @@ class LocalCommands(Commands):
 
         click.secho(f"Instance running!\nVisit https://{host}:{port}", fg="green")
         server.wait()
+        click.secho("Server execution ended.", fg="red")
+        if services:
+            worker.wait()
+            click.secho("Worker execution ended.", fg="red")


### PR DESCRIPTION
There are cases (such as the port being already in use or other fatal errors) when the server closes unexpectedly and the worker process is left running in the background with no easy option to catch it.

:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

I changed the run command, such that it also waits for the worker. I have also add some red messages to point the die event of the server process.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
