### PR TITLE
global: replace FLASK_ENV with FLASK_DEBUG

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,26 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Publish
+
 on:
   push:
     tags:
       - v*
 
 jobs:
-  build-n-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel babel
-      - name: Build package
-        run: |
-          python setup.py sdist bdist_wheel
-      - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.3.1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}
+  Build-N-Publish:
+    uses: inveniosoftware/workflows/.github/workflows/pypi-publish.yml@master
+    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2025 CERN.
 # Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -28,32 +28,8 @@ on:
         default: 'Manual trigger'
 
 jobs:
-  python-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-          python-version: ['3.9', '3.12']
-          requirements-level: [pypi]
-
-    env:
-      EXTRAS: tests
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: setup.cfg
-
-      - name: Install dependencies
-        run: |
-          pip install -e .[$EXTRAS]
-          pip freeze
-
-      - name: Run tests
-        run: |
-          ./run-tests.sh
+  Python:
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
+    with:
+      db-service: '[""]'
+      search-service: '[""]'

--- a/invenio_cli/cli/assets.py
+++ b/invenio_cli/cli/assets.py
@@ -48,7 +48,7 @@ def build(cli_config, no_wipe, production, node_log_file):
     commands = AssetsCommands(cli_config)
     commands.update_statics_and_assets(
         force=not no_wipe,  # If no_wipe=True, it means force=False
-        flask_env="production" if production else "development",
+        debug=not production,
         log_file=node_log_file,
     )
 

--- a/invenio_cli/cli/install.py
+++ b/invenio_cli/cli/install.py
@@ -43,8 +43,11 @@ def install(cli_config, pre, dev, production):
     builds front-end assets.
     """
     commands = InstallCommands(cli_config)
-    flask_env = "production" if production else "development"
-    steps = commands.install(pre=pre, dev=dev, flask_env=flask_env)
+    steps = commands.install(
+        pre=pre,
+        dev=dev,
+        debug=not production,
+    )
     on_fail = "Failed to install dependencies."
     on_success = "Dependencies installed successfully."
 

--- a/invenio_cli/cli/packages.py
+++ b/invenio_cli/cli/packages.py
@@ -8,7 +8,6 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-
 import click
 
 from ..commands import AssetsCommands, PackagesCommands
@@ -70,7 +69,7 @@ def install(cli_config, packages, skip_build, pip_log_file, node_log_file):
     if not skip_build:
         click.secho("Rebuilding assets...")
         AssetsCommands(cli_config).update_statics_and_assets(
-            force=True, flask_env="development", log_file=node_log_file
+            force=True, debug=True, log_file=node_log_file
         )
 
 

--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -7,7 +7,6 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-
 import subprocess
 from pathlib import Path
 
@@ -73,7 +72,7 @@ class AssetsCommands(LocalCommands):
             )
         else:
             return ProcessResponse(
-                error=f"Unable to install dependent packages. "
+                error="Unable to install dependent packages. "
                 "Got error code {status_code}",
                 status_code=status_code,
             )
@@ -118,7 +117,7 @@ class AssetsCommands(LocalCommands):
         prefix = ["pipenv", "run"]
         watch_cmd = prefix + ["invenio", "webpack", "run", "start"]
 
-        with env(FLASK_ENV="development"):
+        with env(FLASK_DEBUG="true"):
             # Collect into statics/ and assets/ folder
             click.secho(
                 "Starting assets watching (press CTRL+C to stop)...", fg="green"

--- a/invenio_cli/commands/commands.py
+++ b/invenio_cli/commands/commands.py
@@ -34,7 +34,7 @@ class Commands(object):
     @classmethod
     def pyshell(cls, debug=False):
         """Start a Python shell."""
-        with env(FLASK_ENV="development" if debug else "production"):
+        with env(FLASK_DEBUG=str(debug)):
             command = ["pipenv", "run", "invenio", "shell"]
             return run_interactive(command, env={"PIPENV_VERBOSITY": "-1"})
 

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -7,11 +7,11 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-from ..helpers import env, filesystem
+from ..helpers import filesystem
 from ..helpers.process import run_cmd
 from .local import LocalCommands
 from .packages import PackagesCommands
-from .steps import CommandStep, FunctionStep
+from .steps import FunctionStep
 
 
 class InstallCommands(LocalCommands):
@@ -61,7 +61,7 @@ class InstallCommands(LocalCommands):
 
         return filesystem.force_symlink(target_path, link_path)
 
-    def install(self, pre, dev=False, flask_env="production"):
+    def install(self, pre, dev=False, debug=False):
         """Development installation steps."""
         steps = self.install_py_dependencies(pre=pre, dev=dev)
         steps.append(
@@ -73,27 +73,27 @@ class InstallCommands(LocalCommands):
             FunctionStep(
                 func=self.symlink_project_file_or_folder,
                 args={"target": "invenio.cfg"},
-                message=f"Symlinking 'invenio.cfg'...",
+                message="Symlinking 'invenio.cfg'...",
             )
         )
         steps.append(
             FunctionStep(
                 func=self.symlink_project_file_or_folder,
                 args={"target": "templates"},
-                message=f"Symlinking 'templates'...",
+                message="Symlinking 'templates'...",
             )
         )
         steps.append(
             FunctionStep(
                 func=self.symlink_project_file_or_folder,
                 args={"target": "app_data"},
-                message=f"Symlinking 'app_data'...",
+                message="Symlinking 'app_data'...",
             )
         )
         steps.append(
             FunctionStep(
                 func=self.update_statics_and_assets,
-                args={"force": True, "flask_env": flask_env},
+                args={"force": True, "debug": debug},
                 message="Updating statics and assets...",
             )
         )

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -78,7 +78,7 @@ class LocalCommands(Commands):
             status_code=0,
         )
 
-    def update_statics_and_assets(self, force, flask_env="production", log_file=None):
+    def update_statics_and_assets(self, force, debug=False, log_file=None):
         """High-level command to update less/js/images/... files.
 
         Needed here (parent) because is used by Assets and Install commands.
@@ -101,7 +101,7 @@ class LocalCommands(Commands):
             "install": "Installing JS dependencies...",
         }
 
-        with env(FLASK_ENV=flask_env):
+        with env(FLASK_DEUBG="true" if debug else "false"):
             for op in ops:
                 if callable(op):
                     response = op()
@@ -153,7 +153,7 @@ class LocalCommands(Commands):
 
         click.secho("Starting up local (development) server...", fg="green")
         run_env = environ.copy()
-        run_env["FLASK_ENV"] = "development" if debug else "production"
+        run_env["FLASK_DEBUG"] = str(debug)
         run_env["INVENIO_SITE_UI_URL"] = f"https://{host}:{port}"
         run_env["INVENIO_SITE_API_URL"] = f"https://{host}:{port}/api"
         server = popen(

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black==0.3.9
+    pytest-black>=0.6.0
     pytest-invenio>=1.4.0
     Sphinx>=4.2.0
 

--- a/tests/commands/test_local.py
+++ b/tests/commands/test_local.py
@@ -159,9 +159,7 @@ def test_install(mock_cli_config):
     commands._update_instance_path.assert_called()
     expected_symlink_calls = [call("invenio.cfg"), call("templates"), call("app_data")]
     assert commands._symlink_project_file_or_folder.mock_calls == expected_symlink_calls
-    commands.update_statics_and_assets.assert_called_with(
-        force=True, flask_env="production"
-    )
+    commands.update_statics_and_assets.assert_called_with(force=True, debug=False)
 
 
 @pytest.mark.skip()
@@ -285,7 +283,7 @@ def test_run(
     commands.run(host=host, port=port, debug=True)
 
     run_env = environ.copy()
-    run_env["FLASK_ENV"] = "development"
+    run_env["FLASK_DEBUG"] = "True"
     run_env["INVENIO_SITE_HOSTNAME"] = f"{host}:{port}"
     expected_calls = [
         call(["pipenv", "run", "celery", "--app", "invenio_app.celery", "worker"]),

--- a/tests/helpers/test_env.py
+++ b/tests/helpers/test_env.py
@@ -15,13 +15,13 @@ from invenio_cli.helpers.env import env
 
 def test_env():
     """Test environment variables context manager."""
-    assert "FLASK_ENV" not in os.environ
+    assert "SERVER_NAME" not in os.environ
     assert "FLASK_DEBUG" not in os.environ
 
     os.environ["FLASK_DEBUG"] = "true"
-    with env(FLASK_ENV="production", FLASK_DEBUG="false"):
-        assert os.environ["FLASK_ENV"] == "production"
+    with env(SERVER_NAME="example.com", FLASK_DEBUG="false"):
+        assert os.environ["SERVER_NAME"] == "example.com"
         assert os.environ["FLASK_DEBUG"] == "false"
 
     assert os.environ["FLASK_DEBUG"] == "true"
-    assert "FLASK_ENV" not in os.environ
+    assert "SERVER_NAME" not in os.environ


### PR DESCRIPTION
* ``FLASK_ENV`` has been removed in Flask v2.3 and ``FLASK_DEBUG`` is
  recommended instead.
* This also makes sure that with Flask v2.3+ debug mode features like hot reloading and assets linking works.