### PR TITLE
Implement `uv` as an optional python package management backend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,14 @@
 Changes
 =======
 
+Version 1.6.0 (released 2025-02-28)
+
+- packages: allow use of either `pipenv` or `uv` as python package manager
+- flask: replace `FLASK_ENV` with `FLASK_DEBUG`
+- celery: allow setting a log level
+- config: make host & port for both web and search configurable via `.invenio.private`
+- run: introduce more fine-granular "web" and "worker" sub-commands
+
 Version 1.5.0 (released 2024-08-01)
 
 - dependencies: update for invenio-app-rdm v12

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,6 @@
 
 from __future__ import print_function
 
-import sphinx.environment
-
 from invenio_cli import __version__
 
 # -- General configuration ------------------------------------------------

--- a/invenio_cli/__init__.py
+++ b/invenio_cli/__init__.py
@@ -9,6 +9,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 __all__ = ("__version__",)

--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019-2021 CERN.
 # Copyright (C) 2019 Northwestern University.
 # Copyright (C) 2022 Forschungszentrum Jülich GmbH.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -213,6 +213,11 @@ worker_options = combine_decorators(
         default=None,
         help="Celery log file (default: None, this means logging to stderr)",
     ),
+    click.option(
+        "--celery-log-level",
+        default="INFO",
+        help="Celery log level (default: INFO)",
+    ),
 )
 
 
@@ -220,7 +225,7 @@ worker_options = combine_decorators(
 @services_option
 @worker_options
 @pass_cli_config
-def run_worker(cli_config, services, celery_log_file):
+def run_worker(cli_config, services, celery_log_file, celery_log_level):
     """Starts the local development server."""
     if services:
         cmds = ServicesCommands(cli_config)
@@ -229,7 +234,9 @@ def run_worker(cli_config, services, celery_log_file):
         handle_process_response(response)
 
     commands = LocalCommands(cli_config)
-    processes = commands.run_worker(celery_log_file=celery_log_file)
+    processes = commands.run_worker(
+        celery_log_file=celery_log_file, celery_log_level=celery_log_level
+    )
     for proc in processes:
         proc.wait()
 
@@ -239,7 +246,7 @@ def run_worker(cli_config, services, celery_log_file):
 @web_options
 @worker_options
 @pass_cli_config
-def run_all(cli_config, host, port, debug, services, celery_log_file):
+def run_all(cli_config, host, port, debug, services, celery_log_file, celery_log_level):
     """Starts web and worker development servers."""
     if services:
         cmds = ServicesCommands(cli_config)
@@ -257,6 +264,7 @@ def run_all(cli_config, host, port, debug, services, celery_log_file):
         debug=debug,
         services=services,
         celery_log_file=celery_log_file,
+        celery_log_level=celery_log_level,
     )
     for proc in processes:
         proc.wait()

--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2021 CERN.
 # Copyright (C) 2019 Northwestern University.
 # Copyright (C) 2022 Forschungszentrum Jülich GmbH.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -163,8 +164,18 @@ services_option = click.option(
     help="Enable/disable dockerized services (default: enabled).",
 )
 web_options = combine_decorators(
-    click.option("--host", "-h", default="127.0.0.1", help="The interface to bind to."),
-    click.option("--port", "-p", default=5000, help="The port to bind to."),
+    click.option(
+        "--host",
+        "-h",
+        default=None,
+        help="The interface to bind to. The default is defined in the CLIConfig.",
+    ),
+    click.option(
+        "--port",
+        "-p",
+        default=None,
+        help="The port to bind to. The default is defined in the CLIConfig.",
+    ),
     click.option(
         "--debug/--no-debug",
         "-d/",
@@ -186,6 +197,9 @@ def run_web(cli_config, host, port, debug, services):
         response = cmds.ensure_containers_running()
         # fail and exit if containers are not running
         handle_process_response(response)
+
+    host = host or cli_config.get_web_host()
+    port = port or cli_config.get_web_port()
 
     commands = LocalCommands(cli_config)
     processes = commands.run_web(host=host, port=str(port), debug=debug)
@@ -232,6 +246,9 @@ def run_all(cli_config, host, port, debug, services, celery_log_file):
         response = cmds.ensure_containers_running()
         # fail and exit if containers are not running
         handle_process_response(response)
+
+    host = host or cli_config.get_web_host()
+    port = port or cli_config.get_web_port()
 
     commands = LocalCommands(cli_config)
     processes = commands.run_all(

--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -73,9 +73,10 @@ def check_requirements(development):
 
 
 @invenio_cli.command()
-def shell():
+@pass_cli_config
+def shell(cli_config):
     """Shell command."""
-    Commands.shell()
+    Commands(cli_config).shell()
 
 
 @invenio_cli.command()
@@ -86,9 +87,10 @@ def shell():
     is_flag=True,
     help="Enable Flask development mode (default: disabled).",
 )
-def pyshell(debug):
+@pass_cli_config
+def pyshell(cli_config, debug):
     """Python shell command."""
-    Commands.pyshell(debug=debug)
+    Commands(cli_config).pyshell(debug=debug)
 
 
 @invenio_cli.command()
@@ -290,9 +292,10 @@ def destroy(cli_config):
 
 @invenio_cli.command()
 @click.option("--script", required=True, help="The path of custom migration script.")
-def upgrade(script):
+@pass_cli_config
+def upgrade(cli_config, script):
     """Upgrades the current instance to a newer version."""
-    steps = UpgradeCommands.upgrade(script)
+    steps = UpgradeCommands(cli_config).upgrade(script)
     on_fail = "Upgrade failed."
     on_success = "Upgrade sucessfull."
 

--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -30,7 +30,12 @@ from .install import install
 from .packages import packages
 from .services import services
 from .translations import translations
-from .utils import handle_process_response, pass_cli_config, run_steps
+from .utils import (
+    combine_decorators,
+    handle_process_response,
+    pass_cli_config,
+    run_steps,
+)
 
 
 @click.group()
@@ -104,8 +109,7 @@ def pyshell(debug):
 @click.option(
     "--user-input/--no-input",
     default=True,
-    help="If input is disabled, uses the defaults (if --config is"
-    " also passed, uses values from an .invenio config file).",
+    help="If input is disabled, uses the defaults (if --config is also passed, uses values from an .invenio config file).",  # noqa
 )
 @click.option(
     "--config", required=False, help="The .invenio configuration file to use."
@@ -142,34 +146,41 @@ def init(flavour, template, checkout, user_input, config):
         cookiecutter_wrapper.remove_config()
 
 
-@invenio_cli.command()
-@click.option("--host", "-h", default="127.0.0.1", help="The interface to bind to.")
-@click.option("--port", "-p", default=5000, help="The port to bind to.")
-@click.option(
-    "--debug/--no-debug",
-    "-d/",
-    default=True,
-    is_flag=True,
-    help="Enable/disable debug mode including auto-reloading " "(default: enabled).",
-)
-@click.option(
+@invenio_cli.group("run", invoke_without_command=True)
+@click.pass_context
+def run_group(ctx):
+    """Run command group."""
+    # For backward compatibility
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(run_all)
+
+
+services_option = click.option(
     "--services/--no-services",
     "-s/-n",
     default=True,
     is_flag=True,
     help="Enable/disable dockerized services (default: enabled).",
 )
-@click.option(
-    "--celery-log-file",
-    default=None,
-    help="Celery log file (default: None, this means logging to stderr)",
+web_options = combine_decorators(
+    click.option("--host", "-h", default="127.0.0.1", help="The interface to bind to."),
+    click.option("--port", "-p", default=5000, help="The port to bind to."),
+    click.option(
+        "--debug/--no-debug",
+        "-d/",
+        default=True,
+        is_flag=True,
+        help="Enable/disable debug mode including auto-reloading (default: enabled).",
+    ),
 )
-@pass_cli_config
-def run(cli_config, host, port, debug, services, celery_log_file):
-    """Starts the local development server.
 
-    NOTE: this only makes sense locally so no --local option
-    """
+
+@run_group.command("web")
+@services_option
+@web_options
+@pass_cli_config
+def run_web(cli_config, host, port, debug, services):
+    """Starts the local development web server."""
     if services:
         cmds = ServicesCommands(cli_config)
         response = cmds.ensure_containers_running()
@@ -177,13 +188,61 @@ def run(cli_config, host, port, debug, services, celery_log_file):
         handle_process_response(response)
 
     commands = LocalCommands(cli_config)
-    commands.run(
+    processes = commands.run_web(host=host, port=str(port), debug=debug)
+    for proc in processes:
+        proc.wait()
+
+
+worker_options = combine_decorators(
+    click.option(
+        "--celery-log-file",
+        default=None,
+        help="Celery log file (default: None, this means logging to stderr)",
+    ),
+)
+
+
+@run_group.command("worker")
+@services_option
+@worker_options
+@pass_cli_config
+def run_worker(cli_config, services, celery_log_file):
+    """Starts the local development server."""
+    if services:
+        cmds = ServicesCommands(cli_config)
+        response = cmds.ensure_containers_running()
+        # fail and exit if containers are not running
+        handle_process_response(response)
+
+    commands = LocalCommands(cli_config)
+    processes = commands.run_worker(celery_log_file=celery_log_file)
+    for proc in processes:
+        proc.wait()
+
+
+@run_group.command("all")
+@services_option
+@web_options
+@worker_options
+@pass_cli_config
+def run_all(cli_config, host, port, debug, services, celery_log_file):
+    """Starts web and worker development servers."""
+    if services:
+        cmds = ServicesCommands(cli_config)
+        response = cmds.ensure_containers_running()
+        # fail and exit if containers are not running
+        handle_process_response(response)
+
+    commands = LocalCommands(cli_config)
+    processes = commands.run_all(
         host=host,
         port=str(port),
         debug=debug,
         services=services,
         celery_log_file=celery_log_file,
     )
+    for proc in processes:
+        proc.wait()
 
 
 @invenio_cli.command()

--- a/invenio_cli/cli/install.py
+++ b/invenio_cli/cli/install.py
@@ -13,7 +13,16 @@ from ..commands import InstallCommands
 from .utils import pass_cli_config, run_steps
 
 
-@click.command()
+@click.group(invoke_without_command=True)
+@click.pass_context
+def install(ctx):
+    """Commands for installing the project."""
+    if ctx.invoked_subcommand is None:
+        # If no sub-command is passed, default to the install all command.
+        ctx.invoke(install_all)
+
+
+@install.command("all")
 @click.option(
     "--pre",
     default=False,
@@ -35,8 +44,8 @@ from .utils import pass_cli_config, run_steps
     " statics/assets.",
 )
 @pass_cli_config
-def install(cli_config, pre, dev, production):
-    """Installs the  project locally.
+def install_all(cli_config, pre, dev, production):
+    """Installs the project locally.
 
     Installs dependencies, creates instance directory,
     links invenio.cfg + templates, copies images and other statics and finally
@@ -50,5 +59,17 @@ def install(cli_config, pre, dev, production):
     )
     on_fail = "Failed to install dependencies."
     on_success = "Dependencies installed successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
+@install.command()
+@pass_cli_config
+def symlink(cli_config):
+    """Symlinks project files in the instance directory."""
+    commands = InstallCommands(cli_config)
+    steps = commands.symlink()
+    on_fail = "Failed to symlink project files and folders."
+    on_success = "Project ffles and folders symlinked successfully."
 
     run_steps(steps, on_fail, on_success)

--- a/invenio_cli/cli/install.py
+++ b/invenio_cli/cli/install.py
@@ -40,8 +40,7 @@ def install(ctx):
     "-p/-d",
     default=False,
     is_flag=True,
-    help="Production mode copies statics/assets. Development mode symlinks"
-    " statics/assets.",
+    help="Production mode copies statics/assets. Development mode symlinks them.",
 )
 @pass_cli_config
 def install_all(cli_config, pre, dev, production):
@@ -93,8 +92,7 @@ def install_python(cli_config, pre, dev):
     "-p/-d",
     default=False,
     is_flag=True,
-    help="Production mode copies statics/assets. Development mode symlinks"
-    " statics/assets.",
+    help="Production mode copies statics/assets. Development mode symlinks them.",
 )
 @pass_cli_config
 def install_assets(cli_config, production):
@@ -115,6 +113,6 @@ def symlink(cli_config):
     commands = InstallCommands(cli_config)
     steps = commands.symlink()
     on_fail = "Failed to symlink project files and folders."
-    on_success = "Project ffles and folders symlinked successfully."
+    on_success = "Project files and folders symlinked successfully."
 
     run_steps(steps, on_fail, on_success)

--- a/invenio_cli/cli/install.py
+++ b/invenio_cli/cli/install.py
@@ -63,6 +63,51 @@ def install_all(cli_config, pre, dev, production):
     run_steps(steps, on_fail, on_success)
 
 
+@install.command("python")
+@click.option(
+    "--pre",
+    default=False,
+    is_flag=True,
+    help="If specified, allows the installation of alpha releases",
+)
+@click.option(
+    "--dev/--no-dev",
+    default=True,
+    is_flag=True,
+    help="Includes development dependencies.",
+)
+@pass_cli_config
+def install_python(cli_config, pre, dev):
+    """Install Python dependencies and packages."""
+    commands = InstallCommands(cli_config)
+    steps = commands.install_py_dependencies(pre=pre, dev=dev)
+    on_fail = "Failed to install Python dependencies."
+    on_success = "Python dependencies installed successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
+@install.command("assets")
+@click.option(
+    "--production/--development",
+    "-p/-d",
+    default=False,
+    is_flag=True,
+    help="Production mode copies statics/assets. Development mode symlinks"
+    " statics/assets.",
+)
+@pass_cli_config
+def install_assets(cli_config, production):
+    """Install assets."""
+    commands = InstallCommands(cli_config)
+    flask_env = "production" if production else "development"
+    steps = commands.install_assets(flask_env)
+    on_fail = "Failed to install assets."
+    on_success = "Assets installed successfully."
+
+    run_steps(steps, on_fail, on_success)
+
+
 @install.command()
 @pass_cli_config
 def symlink(cli_config):

--- a/invenio_cli/cli/packages.py
+++ b/invenio_cli/cli/packages.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020-2021 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -34,7 +34,7 @@ def lock(cli_config, pre, dev):
         + f"Include dev-packages: {dev}.",
         fg="green",
     )
-    steps = PackagesCommands.lock(pre, dev)
+    steps = PackagesCommands(cli_config).lock(pre, dev)
     on_fail = "Failed to lock dependencies."
     on_success = "Dependencies locked successfully."
 
@@ -58,7 +58,7 @@ def install(cli_config, packages, skip_build, pip_log_file, node_log_file):
     if len(packages) < 1:
         raise click.UsageError("You must specify at least one package.")
 
-    steps = PackagesCommands.install_packages(packages, pip_log_file)
+    steps = PackagesCommands(cli_config).install_packages(packages, pip_log_file)
 
     on_fail = f"Failed to install packages {packages}."
     on_success = f"Packages {packages} installed successfully."
@@ -77,7 +77,7 @@ def install(cli_config, packages, skip_build, pip_log_file, node_log_file):
 @pass_cli_config
 def outdated(cli_config):
     """Show outdated Python dependencies."""
-    steps = PackagesCommands.outdated_packages()
+    steps = PackagesCommands(cli_config).outdated_packages()
 
     on_fail = "Some of the packages need to be updated."
     on_success = "All packages are up to date."
@@ -94,11 +94,13 @@ def update(cli_config, version=None):
         db = cli_config.get_db_type()
         search = cli_config.get_search_type()
         package = f"invenio-app-rdm[{db},{search}]~="
-        steps = PackagesCommands.update_package_new_version(package, version)
+        steps = PackagesCommands(cli_config).update_package_new_version(
+            package, version
+        )
         on_fail = f"Failed to update version {version}"
         on_success = f"Version {version} installed successfully."
     else:
-        steps = PackagesCommands.update_packages()
+        steps = PackagesCommands(cli_config).update_packages()
         on_fail = "Failed to update packages."
         on_success = "Packages installed successfully."
 

--- a/invenio_cli/cli/translations.py
+++ b/invenio_cli/cli/translations.py
@@ -31,7 +31,7 @@ def translations():
 def extract(cli_config, babel_ini):
     """Extract messages for i18n support (translations)."""
     click.secho("Extracting messages...", fg="green")
-    steps = TranslationsCommands.extract(
+    steps = TranslationsCommands(cli_config).extract(
         msgid_bugs_address=cli_config.get_author_email(),
         copyright_holder=cli_config.get_author_name(),
         babel_file=cli_config.get_project_dir() / Path("translations/babel.ini"),
@@ -50,7 +50,7 @@ def extract(cli_config, babel_ini):
 def init(cli_config, locale):
     """Initialized message catalog for a given locale."""
     click.secho("Initializing messages catalog...", fg="green")
-    steps = TranslationsCommands.init(
+    steps = TranslationsCommands(cli_config).init(
         output_dir=cli_config.get_project_dir() / Path("translations/"),
         input_file=cli_config.get_project_dir() / Path("translations/messages.pot"),
         locale=locale,
@@ -66,7 +66,7 @@ def init(cli_config, locale):
 def update(cli_config):
     """Update messages catalog."""
     click.secho("Updating messages catalog...", fg="green")
-    steps = TranslationsCommands.update(
+    steps = TranslationsCommands(cli_config).update(
         output_dir=cli_config.get_project_dir() / Path("translations/"),
         input_file=cli_config.get_project_dir() / Path("translations/messages.pot"),
     )
@@ -83,6 +83,7 @@ def compile(cli_config, fuzzy):
     """Compile message catalog."""
     click.secho("Compiling catalog...", fg="green")
     commands = TranslationsCommands(
+        cli_config,
         project_path=cli_config.get_project_dir(),
         instance_path=cli_config.get_instance_path(),
     )

--- a/invenio_cli/cli/translations.py
+++ b/invenio_cli/cli/translations.py
@@ -70,8 +70,8 @@ def update(cli_config):
         output_dir=cli_config.get_project_dir() / Path("translations/"),
         input_file=cli_config.get_project_dir() / Path("translations/messages.pot"),
     )
-    on_fail = f"Failed to update message catalog."
-    on_success = f"Message catalog updated successfully."
+    on_fail = "Failed to update message catalog."
+    on_success = "Message catalog updated successfully."
 
     run_steps(steps, on_fail, on_success)
 

--- a/invenio_cli/cli/utils.py
+++ b/invenio_cli/cli/utils.py
@@ -48,3 +48,14 @@ def handle_process_response(response, fail_message=None):
         click.secho(msg, fg="yellow")
     elif response.output:
         click.secho(message=response.output, fg="green")
+
+
+def combine_decorators(*decorators):
+    """Combine multiple decorators."""
+
+    def _decorator(f):
+        for dec in reversed(decorators):
+            f = dec(f)
+        return f
+
+    return _decorator

--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -113,9 +113,12 @@ class AssetsCommands(LocalCommands):
 
     def watch_assets(self):
         """High-level command to watch assets for changes."""
-        # Commands
-        prefix = ["pipenv", "run"]
-        watch_cmd = prefix + ["invenio", "webpack", "run", "start"]
+        watch_cmd = self.cli_config.python_package_manager.run_command(
+            "invenio",
+            "webpack",
+            "run",
+            "start",
+        )
 
         with env(FLASK_DEBUG="true"):
             # Collect into statics/ and assets/ folder

--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -120,7 +120,7 @@ class AssetsCommands(LocalCommands):
             "start",
         )
 
-        with env(FLASK_DEBUG="true"):
+        with env(FLASK_DEBUG="1"):
             # Collect into statics/ and assets/ folder
             click.secho(
                 "Starting assets watching (press CTRL+C to stop)...", fg="green"

--- a/invenio_cli/commands/commands.py
+++ b/invenio_cli/commands/commands.py
@@ -32,7 +32,7 @@ class Commands(object):
     def pyshell(self, debug=False):
         """Start a Python shell."""
         pkg_man = self.cli_config.python_package_manager
-        with env(FLASK_DEBUG=str(debug)):
+        with env(FLASK_DEBUG="1" if debug else "0"):
             command = pkg_man.run_command("invenio", "shell")
             return run_interactive(command, env={"PIPENV_VERBOSITY": "-1"})
 

--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -34,7 +35,7 @@ class ContainersCommands(ServicesCommands):
         """
         steps = [
             FunctionStep(
-                func=PackagesCommands.is_locked,
+                func=lambda: PackagesCommands(self.cli_config).is_locked(),
                 message="Checking if dependencies are locked.",
             ),
             FunctionStep(
@@ -233,6 +234,7 @@ class ContainersCommands(ServicesCommands):
     def translations(self, project_shortname):
         """Steps to compile translations for the instance."""
         commands = TranslationsCommands(
+            self.cli_config,
             project_path=self.cli_config.get_project_dir(),
             # we use INVENIO_INSTANCE_PATH that is set in the Dockerfile as
             # config.instance_path is set only in development `install` command
@@ -312,7 +314,7 @@ class ContainersCommands(ServicesCommands):
 
         if lock:
             # FIXME: Should this params be accepted? sensible defaults?
-            steps.extend(PackagesCommands.lock(pre=True, dev=True))
+            steps.extend(PackagesCommands(self.cli_config).lock(pre=True, dev=True))
 
         if build:
             steps.extend(self.build())

--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -53,8 +53,7 @@ class ContainersCommands(ServicesCommands):
                 func=self.docker_helper.execute_cli_command,
                 args={
                     "project_shortname": project_shortname,
-                    "command": "invenio shell --no-term-title -c "
-                    "\"import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')\"",  # noqa
+                    "command": "invenio shell --no-term-title -c \"import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')\"",  # noqa
                 },
                 message="Flushing redis cache...",
             ),
@@ -106,9 +105,7 @@ class ContainersCommands(ServicesCommands):
                 func=self.docker_helper.execute_cli_command,
                 args={
                     "project_shortname": project_shortname,
-                    "command": "invenio files location create --default "
-                    "default-location "
-                    "${INVENIO_INSTANCE_PATH}/data",
+                    "command": "invenio files location create --default default-location ${INVENIO_INSTANCE_PATH}/data",  # noqa
                 },
                 message="Creating files location...",
             ),
@@ -124,7 +121,7 @@ class ContainersCommands(ServicesCommands):
                 func=self.docker_helper.execute_cli_command,
                 args={
                     "project_shortname": project_shortname,
-                    "command": "invenio access allow " "superuser-access role admin",
+                    "command": "invenio access allow superuser-access role admin",
                 },
                 message="Assigning superuser access to admin role...",
             ),

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -8,7 +8,6 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-import sys
 
 from ..helpers import filesystem
 from ..helpers.process import run_cmd

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -70,6 +70,7 @@ class InstallCommands(LocalCommands):
                 func=self.update_instance_path, message="Updating instance path..."
             )
         )
+
         steps.extend(
             [
                 FunctionStep(
@@ -82,18 +83,19 @@ class InstallCommands(LocalCommands):
         )
         return steps
 
-    def install(self, pre, dev=False, debug=False):
-        """Development installation steps."""
-        steps = self.install_py_dependencies(pre=pre, dev=dev)
-
-        steps.extend(self.symlink())
-
-        steps.append(
+    def install_assets(self, debug=False):
+        """Install assets."""
+        return [
             FunctionStep(
                 func=self.update_statics_and_assets,
                 args={"force": True, "debug": debug},
                 message="Updating statics and assets...",
             )
-        )
+        ]
 
+    def install(self, pre, dev=False, flask_env="production"):
+        """Development installation steps."""
+        steps = self.install_py_dependencies(pre=pre, dev=dev)
+        steps.extend(self.symlink())
+        steps.extend(self.install_assets(flask_env))
         return steps

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -10,6 +10,7 @@
 
 import os
 import signal
+import sys
 from distutils.dir_util import copy_tree
 from os import environ
 from pathlib import Path
@@ -84,17 +85,16 @@ class LocalCommands(Commands):
         Needed here (parent) because is used by Assets and Install commands.
         """
         # Commands
-        prefix = ["pipenv", "run", "invenio"]
-
-        ops = [prefix + ["collect", "--verbose"]]
+        pkg_man = self.cli_config.python_package_manager
+        ops = [pkg_man.run_command("invenio", "collect", "--verbose")]
 
         if force:
-            ops.append(prefix + ["webpack", "clean", "create"])
-            ops.append(prefix + ["webpack", "install"])
+            ops.append(pkg_man.run_command("invenio", "webpack", "clean", "create"))
+            ops.append(pkg_man.run_command("invenio", "webpack", "install"))
         else:
-            ops.append(prefix + ["webpack", "create"])
+            ops.append(pkg_man.run_command("invenio", "webpack", "create"))
         ops.append(self._statics)
-        ops.append(prefix + ["webpack", "build"])
+        ops.append(pkg_man.run_command("invenio", "webpack", "build"))
         # Keep the same messages for some of the operations for backward compatibility
         messages = {
             "build": "Building assets...",
@@ -135,10 +135,9 @@ class LocalCommands(Commands):
         run_env["FLASK_DEBUG"] = str(debug)
         run_env["INVENIO_SITE_UI_URL"] = f"https://{host}:{port}"
         run_env["INVENIO_SITE_API_URL"] = f"https://{host}:{port}/api"
+        pkg_man = self.cli_config.python_package_manager
         proc = popen(
-            [
-                "pipenv",
-                "run",
+            pkg_man.run_command(
                 "invenio",
                 "run",
                 "--cert",
@@ -151,7 +150,7 @@ class LocalCommands(Commands):
                 port,
                 "--extra-files",
                 "invenio.cfg",
-            ],
+            ),
             env=run_env,
         )
         self._handle_sigint("Web server", proc)
@@ -162,9 +161,8 @@ class LocalCommands(Commands):
         """Run Celery worker."""
         click.secho("Starting celery worker...", fg="green")
 
-        celery_command = [
-            "pipenv",
-            "run",
+        pkg_man = self.cli_config.python_package_manager
+        celery_command = pkg_man.run_command(
             "celery",
             "--app",
             "invenio_app.celery",
@@ -175,7 +173,7 @@ class LocalCommands(Commands):
             celery_log_level,
             "--queues",
             "celery,low",
-        ]
+        )
 
         if celery_log_file:
             celery_command += [

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -101,7 +101,7 @@ class LocalCommands(Commands):
             "install": "Installing JS dependencies...",
         }
 
-        with env(FLASK_DEUBG="true" if debug else "false"):
+        with env(FLASK_DEBUG="1" if debug else "0"):
             for op in ops:
                 if callable(op):
                     response = op()
@@ -132,7 +132,7 @@ class LocalCommands(Commands):
         """Run development server."""
         click.secho("Starting up local (development) server...", fg="green")
         run_env = environ.copy()
-        run_env["FLASK_DEBUG"] = str(debug)
+        run_env["FLASK_DEBUG"] = "1" if debug else "0"
         run_env["INVENIO_SITE_UI_URL"] = f"https://{host}:{port}"
         run_env["INVENIO_SITE_API_URL"] = f"https://{host}:{port}/api"
         pkg_man = self.cli_config.python_package_manager

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -115,50 +115,27 @@ class LocalCommands(Commands):
                     break
         return response
 
-    def run(self, host, port, debug=True, services=True, celery_log_file=None):
-        """Run development server and celery queue."""
+    def _handle_sigint(self, name, process):
+        """Terminate services on SIGINT."""
+        prev_handler = signal.getsignal(signal.SIGINT)
 
-        def signal_handler(sig, frame):
-            click.secho("Stopping server and worker...", fg="green")
-            server.terminate()
-            if services:
-                worker.terminate()
-            click.secho("Server and worker stopped...", fg="green")
+        def _signal_handler(sig, frame):
+            click.secho(f"Stopping {name}...", fg="green")
+            process.terminate()
+            click.secho(f"{name} stopped...", fg="green")
+            if prev_handler is not None:
+                prev_handler(sig, frame)
 
-        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGINT, _signal_handler)
 
-        if services:
-            click.secho("Starting celery worker...", fg="green")
-
-            celery_command = [
-                "pipenv",
-                "run",
-                "celery",
-                "--app",
-                "invenio_app.celery",
-                "worker",
-                "--beat",
-                "--events",
-                "--loglevel",
-                "INFO",
-                "--queues",
-                "celery,low",
-            ]
-
-            if celery_log_file:
-                celery_command += [
-                    "--logfile",
-                    celery_log_file,
-                ]
-
-            worker = popen(celery_command)
-
+    def run_web(self, host, port, debug=True):
+        """Run development server."""
         click.secho("Starting up local (development) server...", fg="green")
         run_env = environ.copy()
         run_env["FLASK_DEBUG"] = str(debug)
         run_env["INVENIO_SITE_UI_URL"] = f"https://{host}:{port}"
         run_env["INVENIO_SITE_API_URL"] = f"https://{host}:{port}/api"
-        server = popen(
+        proc = popen(
             [
                 "pipenv",
                 "run",
@@ -177,6 +154,43 @@ class LocalCommands(Commands):
             ],
             env=run_env,
         )
-
+        self._handle_sigint("Web server", proc)
         click.secho(f"Instance running!\nVisit https://{host}:{port}", fg="green")
-        server.wait()
+        return [proc]
+
+    def run_worker(self, celery_log_file=None):
+        """Run Celery worker."""
+        click.secho("Starting celery worker...", fg="green")
+
+        celery_command = [
+            "pipenv",
+            "run",
+            "celery",
+            "--app",
+            "invenio_app.celery",
+            "worker",
+            "--beat",
+            "--events",
+            "--loglevel",
+            "INFO",
+            "--queues",
+            "celery,low",
+        ]
+
+        if celery_log_file:
+            celery_command += [
+                "--logfile",
+                celery_log_file,
+            ]
+
+        proc = popen(celery_command)
+        self._handle_sigint("Celery worker", proc)
+        click.secho("Worker running!", fg="green")
+        return [proc]
+
+    def run_all(self, host, port, debug=True, services=True, celery_log_file=None):
+        """Run all services."""
+        return [
+            *self.run_web(host, port, debug),
+            *self.run_worker(celery_log_file),
+        ]

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -10,7 +10,6 @@
 
 import os
 import signal
-import sys
 from distutils.dir_util import copy_tree
 from os import environ
 from pathlib import Path

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -158,7 +158,7 @@ class LocalCommands(Commands):
         click.secho(f"Instance running!\nVisit https://{host}:{port}", fg="green")
         return [proc]
 
-    def run_worker(self, celery_log_file=None):
+    def run_worker(self, celery_log_file=None, celery_log_level="INFO"):
         """Run Celery worker."""
         click.secho("Starting celery worker...", fg="green")
 
@@ -172,7 +172,7 @@ class LocalCommands(Commands):
             "--beat",
             "--events",
             "--loglevel",
-            "INFO",
+            celery_log_level,
             "--queues",
             "celery,low",
         ]
@@ -188,9 +188,17 @@ class LocalCommands(Commands):
         click.secho("Worker running!", fg="green")
         return [proc]
 
-    def run_all(self, host, port, debug=True, services=True, celery_log_file=None):
+    def run_all(
+        self,
+        host,
+        port,
+        debug=True,
+        services=True,
+        celery_log_file=None,
+        celery_log_level="INFO",
+    ):
         """Run all services."""
         return [
             *self.run_web(host, port, debug),
-            *self.run_worker(celery_log_file),
+            *self.run_worker(celery_log_file, celery_log_level),
         ]

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -141,6 +141,8 @@ class LocalCommands(Commands):
                 "--events",
                 "--loglevel",
                 "INFO",
+                "--queues",
+                "celery,low",
             ]
 
             if celery_log_file:

--- a/invenio_cli/commands/packages.py
+++ b/invenio_cli/commands/packages.py
@@ -8,7 +8,6 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-import sys
 from os import listdir
 
 from ..helpers.cli_config import CLIConfig

--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -12,10 +12,9 @@
 import json
 import re
 import sys
-from os import listdir
 
 from ..helpers.docker_helper import DockerHelper
-from ..helpers.process import ProcessResponse, run_cmd, run_interactive
+from ..helpers.process import ProcessResponse, run_cmd
 from ..helpers.rdm import rdm_version
 from .steps import FunctionStep
 
@@ -187,7 +186,7 @@ class RequirementsCommands(object):
             return ProcessResponse(
                 output=f"Pipenv OK. Got version {version}.", status_code=0
             )
-        except Exception as err:
+        except Exception:
             return ProcessResponse(
                 error=f"Pipenv not found. Got {result.error}.", status_code=1
             )

--- a/invenio_cli/commands/requirements.py
+++ b/invenio_cli/commands/requirements.py
@@ -36,8 +36,7 @@ class RequirementsCommands(object):
 
         if len(parts) != 3:
             return ProcessResponse(
-                error=f"{binary} incorrect version format or not found. "
-                "Check that it is installed correctly",
+                error=f"{binary} incorrect version format or not found. Check that it is installed correctly",  # noqa
                 status_code=1,
             )
 

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -86,43 +86,40 @@ class ServicesCommands(Commands):
 
     def _cleanup(self):
         """Services cleanup steps."""
+        pkg_man = self.cli_config.python_package_manager
         steps = [
             CommandStep(
-                cmd=[
-                    "pipenv",
-                    "run",
+                cmd=pkg_man.run_command(
                     "invenio",
                     "shell",
                     "--no-term-title",
                     "-c",
-                    "import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')",
-                ],  # noqa
+                    "import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')",  # noqa
+                ),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Flushing Redis...",
                 skippable=True,
             ),
             CommandStep(
-                cmd=["pipenv", "run", "invenio", "db", "destroy", "--yes-i-know"],
+                cmd=pkg_man.run_command("invenio", "db", "destroy", "--yes-i-know"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Destroying database...",
                 skippable=True,
             ),
             CommandStep(
-                cmd=[
-                    "pipenv",
-                    "run",
+                cmd=pkg_man.run_command(
                     "invenio",
                     "index",
                     "destroy",
                     "--force",
                     "--yes-i-know",
-                ],
+                ),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Destroying indices...",
                 skippable=True,
             ),
             CommandStep(
-                cmd=["pipenv", "run", "invenio", "index", "queue", "init", "purge"],
+                cmd=pkg_man.run_command("invenio", "index", "queue", "init", "purge"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Purging queues...",
                 skippable=True,
@@ -145,6 +142,7 @@ class ServicesCommands(Commands):
 
     def _setup(self, demo_data=False):
         """Services initialization steps."""
+        pkg_man = self.cli_config.python_package_manager
         steps = [
             FunctionStep(
                 func=self.services_expected_status,
@@ -152,14 +150,12 @@ class ServicesCommands(Commands):
                 message="Checking services are not setup...",
             ),
             CommandStep(
-                cmd=["pipenv", "run", "invenio", "db", "init", "create"],
+                cmd=pkg_man.run_command("invenio", "db", "init", "create"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating database...",
             ),
             CommandStep(
-                cmd=[
-                    "pipenv",
-                    "run",
+                cmd=pkg_man.run_command(
                     "invenio",
                     "files",
                     "location",
@@ -167,31 +163,29 @@ class ServicesCommands(Commands):
                     "--default",
                     "default-location",
                     self._default_location_path(),
-                ],
+                ),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating files location...",
             ),
             CommandStep(
-                cmd=["pipenv", "run", "invenio", "roles", "create", "admin"],
+                cmd=pkg_man.run_command("invenio", "roles", "create", "admin"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating admin role...",
             ),
             CommandStep(
-                cmd=[
-                    "pipenv",
-                    "run",
+                cmd=pkg_man.run_command(
                     "invenio",
                     "access",
                     "allow",
                     "superuser-access",
                     "role",
                     "admin",
-                ],
+                ),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Allowing superuser access to admin role...",
             ),
             CommandStep(
-                cmd=["pipenv", "run", "invenio", "index", "init"],
+                cmd=pkg_man.run_command("invenio", "index", "init"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating indices...",
             ),
@@ -203,26 +197,22 @@ class ServicesCommands(Commands):
                 steps.extend(
                     [
                         CommandStep(
-                            cmd=[
-                                "pipenv",
-                                "run",
+                            cmd=pkg_man.run_command(
                                 "invenio",
                                 "rdm-records",
                                 "custom-fields",
                                 "init",
-                            ],
+                            ),
                             env={"PIPENV_VERBOSITY": "-1"},
                             message="Creating custom fields for records...",
                         ),
                         CommandStep(
-                            cmd=[
-                                "pipenv",
-                                "run",
+                            cmd=pkg_man.run_command(
                                 "invenio",
                                 "communities",
                                 "custom-fields",
                                 "init",
-                            ],
+                            ),
                             env={"PIPENV_VERBOSITY": "-1"},
                             message="Creating custom fields for communities...",
                         ),
@@ -240,7 +230,7 @@ class ServicesCommands(Commands):
             if demo_data:
                 steps.extend(self.demo())
         elif ils_version():
-            cmd = ["pipenv", "run", "invenio", "setup", "--verbose"]
+            cmd = pkg_man.run_command("invenio", "setup", "--verbose")
             if not demo_data:
                 cmd.append("--skip-demo-data")
             steps.extend(
@@ -265,9 +255,10 @@ class ServicesCommands(Commands):
 
     def demo(self):
         """Steps to add demo records into the instance."""
+        pkg_man = self.cli_config.python_package_manager
         steps = [
             CommandStep(
-                cmd=["pipenv", "run", "invenio", "rdm-records", "demo"],
+                cmd=pkg_man.run_command("invenio", "rdm-records", "demo"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating demo records...",
             )
@@ -277,13 +268,15 @@ class ServicesCommands(Commands):
 
     def declare_queues(self):
         """Steps to declare the MQ queues required for statistics, etc."""
-        command = ["pipenv", "run", "invenio", "queues", "declare"]
+        pkg_man = self.cli_config.python_package_manager
+        command = pkg_man.run_command("invenio", "queues", "declare")
         steps = [CommandStep(cmd=command, message="Declaring queues...")]
         return steps
 
     def fixtures(self):
         """Steps to set up the required fixtures for the instance."""
-        command = ["pipenv", "run", "invenio", "rdm-records", "fixtures"]
+        pkg_man = self.cli_config.python_package_manager
+        command = pkg_man.run_command("invenio", "rdm-records", "fixtures")
         steps = [
             CommandStep(
                 cmd=command,
@@ -296,7 +289,8 @@ class ServicesCommands(Commands):
 
     def rdm_fixtures(self):
         """Steps to set up the rdm fixtures for the instance."""
-        command = ["pipenv", "run", "invenio", "rdm", "fixtures"]
+        pkg_man = self.cli_config.python_package_manager
+        command = pkg_man.run_command("invenio", "rdm", "fixtures")
         steps = [
             CommandStep(
                 cmd=command,
@@ -310,6 +304,7 @@ class ServicesCommands(Commands):
     def translations(self):
         """Steps to compile translations."""
         commands = TranslationsCommands(
+            self.cli_config,
             project_path=self.cli_config.get_project_dir(),
             instance_path=self.cli_config.get_instance_path(),
         )

--- a/invenio_cli/commands/translations.py
+++ b/invenio_cli/commands/translations.py
@@ -7,7 +7,6 @@
 
 """Invenio module to ease the creation and management of applications."""
 
-from pathlib import Path
 
 from ..commands import Commands
 from ..helpers.cli_config import CLIConfig
@@ -87,7 +86,7 @@ class TranslationsCommands(Commands):
             CommandStep(
                 cmd=cmd,
                 env={"PIPENV_VERBOSITY": "-1"},
-                message=f"Updating message catalog...",
+                message="Updating message catalog...",
             )
         ]
 
@@ -115,7 +114,7 @@ class TranslationsCommands(Commands):
             CommandStep(
                 cmd=cmd,
                 env={"PIPENV_VERBOSITY": "-1"},
-                message=f"Compiling message catalog...",
+                message="Compiling message catalog...",
                 skippable=True,
             ),
         ]

--- a/invenio_cli/commands/translations.py
+++ b/invenio_cli/commands/translations.py
@@ -10,6 +10,7 @@
 from pathlib import Path
 
 from ..commands import Commands
+from ..helpers.cli_config import CLIConfig
 from ..helpers.filesystem import force_symlink
 from .steps import CommandStep, FunctionStep
 
@@ -17,16 +18,14 @@ from .steps import CommandStep, FunctionStep
 class TranslationsCommands(Commands):
     """Translations CLI commands."""
 
-    CMD_PREFIX = ["pipenv", "run"]
-
-    def __init__(self, project_path, instance_path):
+    def __init__(self, cli_config: CLIConfig, project_path=None, instance_path=None):
         """Constructor."""
+        self.cli_config = cli_config
         self.project_path = project_path
         self.instance_path = instance_path
 
-    @classmethod
     def extract(
-        cls,
+        self,
         babel_file,
         output_file,
         input_dirs,
@@ -35,7 +34,8 @@ class TranslationsCommands(Commands):
         add_comments="NOTE",
     ):
         """Extract messages from source code and templates."""
-        cmd = cls.CMD_PREFIX + [
+        pkg_man = self.cli_config.python_package_manager
+        cmd = pkg_man.run_command(
             "pybabel",
             "extract",
             f"--mapping-file={babel_file}",
@@ -44,7 +44,7 @@ class TranslationsCommands(Commands):
             f"--msgid-bugs-address={msgid_bugs_address}",
             f"--copyright-holder={copyright_holder}",
             f"--add-comments={add_comments}",
-        ]
+        )
 
         return [
             CommandStep(
@@ -54,16 +54,16 @@ class TranslationsCommands(Commands):
             )
         ]
 
-    @classmethod
-    def init(cls, output_dir, input_file, locale):
+    def init(self, output_dir, input_file, locale):
         """Initialize a new language catalog."""
-        cmd = cls.CMD_PREFIX + [
+        pkg_man = self.cli_config.python_package_manager
+        cmd = pkg_man.run_command(
             "pybabel",
             "init",
             f"--output-dir={output_dir}",
             f"--input-file={input_file}",
             f"--locale={locale}",
-        ]
+        )
 
         return [
             CommandStep(
@@ -73,15 +73,15 @@ class TranslationsCommands(Commands):
             )
         ]
 
-    @classmethod
-    def update(cls, output_dir, input_file):
+    def update(self, output_dir, input_file):
         """Update the message catalog."""
-        cmd = cls.CMD_PREFIX + [
+        pkg_man = self.cli_config.python_package_manager
+        cmd = pkg_man.run_command(
             "pybabel",
             "update",
             f"--output-dir={output_dir}",
             f"--input-file={input_file}",
-        ]
+        )
 
         return [
             CommandStep(
@@ -100,12 +100,13 @@ class TranslationsCommands(Commands):
     ):
         """Compile the message catalog."""
         directory = directory or self.project_path / translation_folder
+        pkg_man = self.cli_config.python_package_manager
 
-        cmd = self.CMD_PREFIX + [
+        cmd = pkg_man.run_command(
             "pybabel",
             "compile",
             f"--directory={directory}",
-        ]
+        )
 
         if fuzzy:
             cmd.append("--use-fuzzy")

--- a/invenio_cli/commands/upgrade.py
+++ b/invenio_cli/commands/upgrade.py
@@ -7,14 +7,18 @@
 
 """Invenio module to ease the creation and management of applications."""
 
+from ..helpers.cli_config import CLIConfig
 from .steps import CommandStep
 
 
 class UpgradeCommands(object):
     """Local installation commands."""
 
-    @staticmethod
-    def upgrade(script_path):
+    def __init__(self, cli_config: CLIConfig):
+        """Constructor."""
+        self.cli_config = cli_config
+
+    def upgrade(self, script_path):
         """Steps to perform an upgrade of the invenio instance.
 
         First, and alembic upgrade is launched to allow alembic to migrate the
@@ -23,13 +27,19 @@ class UpgradeCommands(object):
         Last, the search indices are destroyed, initialized and rebuilt.
         It is a class method since it does not require any configuration.
         """
-        prefix = ["pipenv", "run", "invenio"]
-        alembic_cmd = prefix + ["alembic", "upgrade"]
-        destroy_index_cmd = prefix + ["index", "destroy", "--yes-i-know"]
-        init_index_cmd = prefix + ["index", "init"]
-        rec_rebuild_index_cmd = prefix + ["rdm-records", "rebuild-index"]
-        comm_rebuild_index_cmd = prefix + ["communities", "rebuild-index"]
-        script_cmd = prefix + ["shell", script_path]
+        pkg_man = self.cli_config.python_package_manager
+        alembic_cmd = pkg_man.run_command("invenio", "alembic", "upgrade")
+        destroy_index_cmd = pkg_man.run_command(
+            "invenio", "index", "destroy", "--yes-i-know"
+        )
+        init_index_cmd = pkg_man.run_command("invenio", "index", "init")
+        rec_rebuild_index_cmd = pkg_man.run_command(
+            "invenio", "rdm-records", "rebuild-index"
+        )
+        comm_rebuild_index_cmd = pkg_man.run_command(
+            "invenio", "communities", "rebuild-index"
+        )
+        script_cmd = pkg_man.run_command("invenio", "shell", script_path)
 
         steps = [
             CommandStep(

--- a/invenio_cli/helpers/__init__.py
+++ b/invenio_cli/helpers/__init__.py
@@ -13,3 +13,10 @@ from .cookiecutter_wrapper import CookiecutterWrapper
 from .docker_helper import DockerHelper
 from .env import env
 from .filesystem import get_created_files
+
+__all__ = (
+    "CookiecutterWrapper",
+    "DockerHelper",
+    "env",
+    "get_created_files",
+)

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -120,6 +120,14 @@ class CLIConfig(object):
             "localhost",
         )
 
+    def get_web_port(self):
+        """Returns web port."""
+        return self.config[CLIConfig.COOKIECUTTER_SECTION].get("web_port", "5000")
+
+    def get_web_host(self):
+        """Returns web host."""
+        return self.config[CLIConfig.COOKIECUTTER_SECTION].get("web_host", "127.0.0.1")
+
     def get_db_type(self):
         """Returns the database type (mysql, postgresql)."""
         return self.config[CLIConfig.COOKIECUTTER_SECTION]["database"]

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -49,8 +49,7 @@ class CLIConfig(object):
                 self.config.read_file(cfg_file)
         except FileNotFoundError as e:
             raise InvenioCLIConfigError(
-                "Missing '{0}' file in current directory. "
-                "Are you in the project folder?".format(e.filename),
+                f"Missing '{e.filename}' file in current directory. Are you in the project folder?",  # noqa
             )
 
         try:

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -133,22 +133,22 @@ class CLIConfig(object):
 
     def get_search_port(self):
         """Returns the search port."""
-        return self.config[CLIConfig.COOKIECUTTER_SECTION].get("search_port", "9200")
+        return self.private_config[CLIConfig.CLI_SECTION].get("search_port", "9200")
 
     def get_search_host(self):
         """Returns the search host."""
-        return self.config[CLIConfig.COOKIECUTTER_SECTION].get(
+        return self.private_config[CLIConfig.CLI_SECTION].get(
             "search_host",
             "localhost",
         )
 
     def get_web_port(self):
         """Returns web port."""
-        return self.config[CLIConfig.COOKIECUTTER_SECTION].get("web_port", "5000")
+        return self.private_config[CLIConfig.CLI_SECTION].get("web_port", "5000")
 
     def get_web_host(self):
         """Returns web host."""
-        return self.config[CLIConfig.COOKIECUTTER_SECTION].get("web_host", "127.0.0.1")
+        return self.private_config[CLIConfig.CLI_SECTION].get("web_host", "127.0.0.1")
 
     def get_db_type(self):
         """Returns the database type (mysql, postgresql)."""

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from ..errors import InvenioCLIConfigError
 from .filesystem import get_created_files
+from .package_managers import UV, Pipenv, PythonPackageManager
 from .process import ProcessResponse
 
 
@@ -39,9 +40,10 @@ class CLIConfig(object):
 
         :param config_dir: Path to general cli config file.
         """
-        self.config_path = Path(project_dir) / self.CONFIG_FILENAME
+        self.project_path = Path(project_dir)
+        self.config_path = self.project_path / self.CONFIG_FILENAME
         self.config = ConfigParser()
-        self.private_config_path = Path(project_dir) / self.PRIVATE_CONFIG_FILENAME
+        self.private_config_path = self.project_path / self.PRIVATE_CONFIG_FILENAME
         self.private_config = ConfigParser()
 
         try:
@@ -59,6 +61,26 @@ class CLIConfig(object):
             CLIConfig._write_private_config(Path(project_dir))
             with open(self.private_config_path) as cfg_file:
                 self.private_config.read_file(cfg_file)
+
+    @property
+    def python_package_manager(self) -> PythonPackageManager:
+        """Get python packages manager."""
+        manager_name = self.config[CLIConfig.CLI_SECTION].get(
+            "python_package_manager", None
+        )
+        if manager_name == Pipenv.name:
+            return Pipenv()
+        elif manager_name == UV.name:
+            return UV()
+
+        if (self.project_path / "Pipfile").is_file():
+            return Pipenv()
+        elif (self.project_path / "pyproject.toml").is_file():
+            return UV()
+        else:
+            raise RuntimeError(
+                "Could not determine the Python package manager, please configure it."
+            )
 
     def get_project_dir(self):
         """Returns path to project directory."""

--- a/invenio_cli/helpers/filesystem.py
+++ b/invenio_cli/helpers/filesystem.py
@@ -60,6 +60,6 @@ def force_symlink(target, link_name):
         if e.errno == errno.EEXIST:
             remove(link_name)
             symlink(target, link_name)
-            output = output + "Deleted already existing link."
+            output = f"{output} Deleted already existing link."
 
     return ProcessResponse(output=output, status_code=0)

--- a/invenio_cli/helpers/package_managers.py
+++ b/invenio_cli/helpers/package_managers.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 TU Wien.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Wrappers around various package managers to be used under the hood."""
+
+import os
+from abc import ABC
+from typing import List
+
+
+class PythonPackageManager(ABC):
+    """Interface for creating tool-specific Python package management commands."""
+
+    name: str = None
+    lock_file_name: str = None
+
+    def run_command(self, *command: str) -> List[str]:
+        """Generate command to run the given command in the managed environment."""
+        raise NotImplementedError()
+
+    def editable_dev_install(self, package: str) -> List[str]:
+        """Install the local packages as editable, but ignore it for locking."""
+        raise NotImplementedError()
+
+    def install_package(self, package: str, version: str = None) -> List[str]:
+        """Install the package in the specified version."""
+        raise NotImplementedError()
+
+    def update_packages(self) -> List[str]:
+        """Update all updated packages."""
+        raise NotImplementedError()
+
+    def list_outdated_packages(self) -> List[str]:
+        """List outdated installed packages."""
+        raise NotImplementedError()
+
+    def install_locked_deps(self, prereleases: bool, devtools: bool) -> List[str]:
+        """Install the packages according to the lock file."""
+        raise NotImplementedError()
+
+    def lock_dependencies(self, prereleases: bool, devtools: bool) -> List[str]:
+        """Update the lock file."""
+        raise NotImplementedError()
+
+    def remove_venv(self) -> List[str]:
+        """Remove the created virtualenv."""
+        raise NotImplementedError()
+
+    def start_activated_subshell(self) -> List[str]:
+        """Remove the created virtualenv."""
+        raise NotImplementedError()
+
+
+class Pipenv(PythonPackageManager):
+    """Generate ``pipenv`` commands for managing Python packages."""
+
+    name = "pipenv"
+    lock_file_name = "Pipfile.lock"
+
+    def run_command(self, *command):
+        """Generate command to run the given command in the managed environment."""
+        return [self.name, "run", *command]
+
+    def editable_dev_install(self, *packages):
+        """Install the local packages as editable, but ignore it for locking."""
+        cmd = [self.name, "run", "pip", "install"]
+        for package in packages:
+            cmd += ["-e", package]
+        return cmd
+
+    def install_package(self, package, version=None):
+        """Install the package in the specified version."""
+        package_version = package if not version else package + version
+        return [self.name, "install", package_version]
+
+    def update_packages(self):
+        """Update all updated packages."""
+        return [self.name, "update"]
+
+    def list_outdated_packages(self):
+        """List outdated installed packages."""
+        return [self.name, "update", "--outdated"]
+
+    def install_locked_deps(self, prereleases, devtools):
+        """Install the packages according to the lock file."""
+        cmd = [self.name, "sync"]
+        if prereleases:
+            cmd += ["--pre"]
+        if devtools:
+            cmd += ["--dev"]
+        return cmd
+
+    def lock_dependencies(self, prereleases, devtools):
+        """Update the lock file."""
+        cmd = [self.name, "lock"]
+        if prereleases:
+            cmd += ["--pre"]
+        if devtools:
+            cmd += ["--dev"]
+        return cmd
+
+    def remove_venv(self):
+        """Remove the created virtualenv."""
+        return ["pipenv", "--rm"]
+
+    def start_activated_subshell(self) -> List[str]:
+        """Remove the created virtualenv."""
+        return ["pipenv", "shell"]
+
+
+class UV(PythonPackageManager):
+    """Generate ``uv`` commands for managing Python packages."""
+
+    name = "uv"
+    lock_file_name = "uv.lock"
+
+    def run_command(self, *command):
+        """Generate command to run the given command in the managed environment."""
+        # "--no-sync" is used to not override locally installed editable packages
+        return [self.name, "run", "--no-sync", *command]
+
+    def editable_dev_install(self, *packages):
+        """Install the local packages as editable, but ignore it for locking."""
+        cmd = [self.name, "pip", "install"]
+        for package in packages:
+            cmd += ["-e", package]
+        return cmd
+
+    def install_package(self, package, version=None):
+        """Install the package in the specified version."""
+        package_version = package if not version else package + version
+        return [self.name, "add", package_version]
+
+    def update_packages(self):
+        """Update all updated packages."""
+        return [self.name, "sync", "--upgrade"]
+
+    def list_outdated_packages(self):
+        """List outdated installed packages."""
+        return [self.name, "sync", "--upgrade", "--dry-run"]
+
+    def install_locked_deps(self, prereleases, devtools):
+        """Install the packages according to the lock file."""
+        cmd = [self.name, "sync"]
+        if prereleases:
+            cmd += ["--prerelease", "allow"]
+        if not devtools:
+            cmd += ["--no-dev"]
+        return cmd
+
+    def lock_dependencies(self, prereleases, devtools):
+        """Update the lock file."""
+        cmd = [self.name, "lock"]
+        if prereleases:
+            cmd += ["--prerelease", "allow"]
+        return cmd
+
+    def remove_venv(self):
+        """Remove the created virtualenv."""
+        # This assumes the default location for the uv venv
+        return ["rm", "-r", ".venv"]
+
+    def start_activated_subshell(self) -> List[str]:
+        """Remove the created virtualenv."""
+        # This assumes we're using a Unixoid OS...
+        # Since Invenio doesn't support Windows that should be given
+        # Also, it has a good chance of not properly setting a PS1...
+        shell = os.getenv("SHELL")
+        return [shell, "-c", f"source .venv/bin/activate; exec {shell} -i"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2019 CERN.
 # Copyright (C) 2019 Northwestern University.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -28,10 +28,10 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     Babel>=2.8
-    cookiecutter>=2.0.0,<2.2.0
-    click>=7.1.1,<8.2
-    click-default-group>=1.2.2,<2.0.0
-    docker>=7.1.0,<8.0.0
+    cookiecutter>=2.0.0
+    click>=7.1.1
+    click-default-group>=1.2.2
+    docker>=7.1.0
     pipfile>=0.0.2
     pipenv>=2020.6.2
     PyYAML>=5.1.2

--- a/tests/commands/test_containers.py
+++ b/tests/commands/test_containers.py
@@ -23,8 +23,7 @@ def expected_setup_calls():
         call("project-shortname", "invenio db init create"),
         call(
             "project-shortname",
-            "invenio files location create --default default-location "
-            "${INVENIO_INSTANCE_PATH}/data",
+            "invenio files location create --default default-location ${INVENIO_INSTANCE_PATH}/data",  # noqa
         ),
         call("project-shortname", "invenio roles create admin"),
         call("project-shortname", "invenio access allow superuser-access role admin"),
@@ -43,8 +42,7 @@ def expected_force_calls():
     return [
         call(
             "project-shortname",
-            "invenio shell --no-term-title -c "
-            "\"import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')\"",  # noqa
+            "invenio shell --no-term-title -c \"import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')\"",  # noqa
         ),
         call("project-shortname", "invenio db destroy --yes-i-know"),
         call("project-shortname", "invenio index destroy --force --yes-i-know"),

--- a/tests/commands/test_containers.py
+++ b/tests/commands/test_containers.py
@@ -16,7 +16,6 @@ import pytest
 from invenio_cli.commands import ContainersCommands
 
 
-@pytest.mark.skip()
 @pytest.fixture(scope="function")
 def expected_setup_calls():
     return [
@@ -36,7 +35,6 @@ def expected_setup_calls():
     ]
 
 
-@pytest.mark.skip()
 @pytest.fixture(scope="function")
 def expected_force_calls():
     return [

--- a/tests/commands/test_local.py
+++ b/tests/commands/test_local.py
@@ -283,7 +283,7 @@ def test_run(
     commands.run(host=host, port=port, debug=True)
 
     run_env = environ.copy()
-    run_env["FLASK_DEBUG"] = "True"
+    run_env["FLASK_DEBUG"] = "1"
     run_env["INVENIO_SITE_HOSTNAME"] = f"{host}:{port}"
     expected_calls = [
         call(["pipenv", "run", "celery", "--app", "invenio_app.celery", "worker"]),

--- a/tests/helpers/test_cli_config.py
+++ b/tests/helpers/test_cli_config.py
@@ -10,7 +10,6 @@
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/helpers/test_cookiecutter_wrapper.py
+++ b/tests/helpers/test_cookiecutter_wrapper.py
@@ -17,8 +17,8 @@ def test_constructor():
     assert cookiecutter.tmp_file is None
     assert cookiecutter.flavour == "RDM"
     assert (
-        cookiecutter.template == "https://github.com/inveniosoftware/"
-        "cookiecutter-invenio-rdm.git"
+        cookiecutter.template
+        == "https://github.com/inveniosoftware/cookiecutter-invenio-rdm.git"
     )
     assert cookiecutter.template_name == "cookiecutter-invenio-rdm"
     assert cookiecutter.checkout == "master"

--- a/tests/helpers/test_env.py
+++ b/tests/helpers/test_env.py
@@ -18,10 +18,10 @@ def test_env():
     assert "SERVER_NAME" not in os.environ
     assert "FLASK_DEBUG" not in os.environ
 
-    os.environ["FLASK_DEBUG"] = "true"
-    with env(SERVER_NAME="example.com", FLASK_DEBUG="false"):
+    os.environ["FLASK_DEBUG"] = "1"
+    with env(SERVER_NAME="example.com", FLASK_DEBUG="0"):
         assert os.environ["SERVER_NAME"] == "example.com"
-        assert os.environ["FLASK_DEBUG"] == "false"
+        assert os.environ["FLASK_DEBUG"] == "0"
 
-    assert os.environ["FLASK_DEBUG"] == "true"
+    assert os.environ["FLASK_DEBUG"] == "1"
     assert "SERVER_NAME" not in os.environ


### PR DESCRIPTION
# Context
This is a variant of #383 with the `pnpm`/`rspack` stuff stripped out, and some squashed commits.
It only touches `uv`, since that's quite uncontroversial and works well enough already.

# How to set the Python package manager
If you have a `Pipfile` in your project, then `pipenv` will be used by default.
If you have `pyproject.toml` and no `Pipfile`, then `uv` will be used by default.
If your use case is not satisfied by this auto-magic, then you can explicitly configure the package manager to use in `.invenio`:
```ini
[cli]
flavour = RDM
python_package_manager = uv
```
Note the lack of quotes around the value `uv`.
Currently, only `uv` and `pipenv` are supported as values.