### PR TITLE
Enable PNPM (rspack is part of Invenio-Assets)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version 1.7.0 (released 2025-03-28)
+
+- build: allow use of either `npm` or `pnpm` as JS package manager (via `.invenio`)
+
 Version 1.6.1 (released 2025-03-27)
 
 - versions: consider `pyproject.toml` when checking `App-{RDM,ILS}` dependency versions

--- a/invenio_cli/__init__.py
+++ b/invenio_cli/__init__.py
@@ -9,6 +9,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"
 
 __all__ = ("__version__",)

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -84,16 +84,17 @@ class LocalCommands(Commands):
         Needed here (parent) because is used by Assets and Install commands.
         """
         # Commands
-        pkg_man = self.cli_config.python_package_manager
-        ops = [pkg_man.run_command("invenio", "collect", "--verbose")]
+        py_pkg_man = self.cli_config.python_package_manager
+        js_pkg_man = self.cli_config.javascript_package_manager
+        ops = [py_pkg_man.run_command("invenio", "collect", "--verbose")]
 
         if force:
-            ops.append(pkg_man.run_command("invenio", "webpack", "clean", "create"))
-            ops.append(pkg_man.run_command("invenio", "webpack", "install"))
+            ops.append(py_pkg_man.run_command("invenio", "webpack", "clean", "create"))
+            ops.append(py_pkg_man.run_command("invenio", "webpack", "install"))
         else:
-            ops.append(pkg_man.run_command("invenio", "webpack", "create"))
+            ops.append(py_pkg_man.run_command("invenio", "webpack", "create"))
         ops.append(self._statics)
-        ops.append(pkg_man.run_command("invenio", "webpack", "build"))
+        ops.append(py_pkg_man.run_command("invenio", "webpack", "build"))
         # Keep the same messages for some of the operations for backward compatibility
         messages = {
             "build": "Building assets...",
@@ -108,7 +109,9 @@ class LocalCommands(Commands):
                     if op[-1] in messages:
                         click.secho(messages[op[-1]], fg="green")
                     response = run_interactive(
-                        op, env={"PIPENV_VERBOSITY": "-1"}, log_file=log_file
+                        op,
+                        env={"PIPENV_VERBOSITY": "-1", **js_pkg_man.env_overrides()},
+                        log_file=log_file,
                     )
                 if response.status_code != 0:
                     break

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -11,11 +11,19 @@
 """Invenio-cli configuration file."""
 
 from configparser import ConfigParser
+from functools import cached_property
 from pathlib import Path
 
 from ..errors import InvenioCLIConfigError
 from .filesystem import get_created_files
-from .package_managers import UV, Pipenv, PythonPackageManager
+from .package_managers import (
+    NPM,
+    PNPM,
+    UV,
+    JavascriptPackageManager,
+    Pipenv,
+    PythonPackageManager,
+)
 from .process import ProcessResponse
 
 
@@ -62,12 +70,10 @@ class CLIConfig(object):
             with open(self.private_config_path) as cfg_file:
                 self.private_config.read_file(cfg_file)
 
-    @property
+    @cached_property
     def python_package_manager(self) -> PythonPackageManager:
         """Get python packages manager."""
-        manager_name = self.config[CLIConfig.CLI_SECTION].get(
-            "python_package_manager", None
-        )
+        manager_name = self.config[CLIConfig.CLI_SECTION].get("python_package_manager")
         if manager_name == Pipenv.name:
             return Pipenv()
         elif manager_name == UV.name:
@@ -81,6 +87,19 @@ class CLIConfig(object):
             raise RuntimeError(
                 "Could not determine the Python package manager, please configure it."
             )
+
+    @cached_property
+    def javascript_package_manager(self) -> JavascriptPackageManager:
+        """Get javascript packages manager."""
+        manager_name = self.config[CLIConfig.CLI_SECTION].get(
+            "javascript_package_manager"
+        )
+        if manager_name == NPM.name:
+            return NPM()
+        elif manager_name == PNPM.name:
+            return PNPM()
+
+        return NPM()
 
     def get_project_dir(self):
         """Returns path to project directory."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     pipfile>=0.0.2
     pipenv>=2020.6.2
     PyYAML>=5.1.2
-    pynpm>=0.1.2
+    pynpm>=0.3.0
     virtualenv>=20.0.35
     tomli>=1.1.0;python_version<"3.11"
 


### PR DESCRIPTION
# Information (updated 2025-03-28)

This PR is the frontend cousin of https://github.com/inveniosoftware/invenio-cli/pull/384 (which similarly enabled `uv` for python).

## Enabling `pnpm`

Note: This feature requires `flask-webpackext` v2.1.0

Similar to `uv`, `pnpm` can be enabled in `.invenio` (which is the "public" configuration file that is intended to be shared between developers via version control).
Unlike `uv`, there are (currently [1]) no artifacts in the project directory that would indicate whether `npm` or `pnpm` should be used and thus the fallback is simply `npm` (i.e. `pnpm` has to be explicitly configured).

Configuration in `.invenio`:
```ini
[cli]
flavour = RDM
logfile = /logs/invenio-cli.log
javascript_package_manager = pnpm
```

[1] this may change once the "reusable frontend lock file" logic gets merged as:
* `package.lock` -> `npm`
* `pnpm-lock.yaml` -> `pnpm`


## Enabling `rspack`

Note: This feature requires `invenio-assets` v4.1.0 (or v3.2.0 for InvenioRDM v12)

`invenio.cfg`:
```py
# somewhere in the file...
WEBPACKEXT_PROJECT = "invenio_assets.webpack:rspack_project"
```

Like any other configuration item, it could alternatively be specified as an env var with prefix (`INVENIO_WEBPACKEXT_PROJECT="invenio_assets.webpack:rspack_project"`), but this is out of scope for here – iykyk.

## Why aren't `pnpm` and `rspack` both configured in `invenio.cfg`?

While it may seem strange that `rspack` uses a different configuration mechanism (`invenio.cfg`) than `pnpm` (`.invenio`), the reason here is simple:
1) The frontend build project was already previously configurable via a configuration item (old default: `WEBPACKEXT_PROJECT = "invenio_assets.webpack:project"`) that could for instance be configured via `invenio.cfg`.
2) The `pnpm` switch did **not** exist previously, and **both** `invenio-cli` as well as `invenio` (the application) have to agree on which JS package manager is used (and `invenio-cli` does not parse `invenio.cfg` itself).


## What's with `react-invenio-forms` and `pnpm`?

The [`link-dist` script in Invenio-y JS packages](https://github.com/inveniosoftware/react-invenio-forms/blob/master/package.json#L16) is geared towards `npm link` and thus obviously won't work nicely for `pnpm`.
(Also, requiring these nonstandard script entries means that only these Invenio-y JS packages are compatible.)
This should likely be reworked in these JS packages, but that's a bit too much effort for now.

For now, we've decided to simply write the `pnpm` logic to perform basically the same steps as `npm` would, except for the actual linking step (which only requires a single step with `pnpm`).
For those interested, I recommend searching the comments mentioning `prepostlink-dist` and others.


# More context (for historical reasons)

Second part of #383 – support for `pnpm` and `rspack`

This PR won't work as standalone, it still requires changes to core Invenio packages.
Either https://github.com/inveniosoftware/invenio-assets/pull/176
Or https://github.com/inveniosoftware/invenio-assets/pull/172, https://github.com/inveniosoftware/flask-webpackext/pull/26, https://github.com/inveniosoftware/pywebpack/pull/47
Depending on the choice, some tweaks need to be performed in this PR here.

~~Also, `npm` is still hard-coded in [React-Invenio-Forms](https://github.com/inveniosoftware/react-invenio-forms/blob/master/package.json#L16) which needs to be addressed.~~
Edit: This has been resolved, see above.