### PR TITLE
rpc-server: use

### DIFF
--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -44,7 +44,7 @@ class InstallCommands(LocalCommands):
                 "shell",
                 "--no-term-title",
                 "-c",
-                "\"print(app.instance_path, end='')\"",
+                "print(app.instance_path, end='')",
             )
         )
         if result.status_code == 0:

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -39,7 +39,7 @@ class InstallCommands(LocalCommands):
     def update_instance_path(self):
         """Update path to instance in config."""
         result = run_cmd(
-            self.cli_config.python_package_manager.run_command(
+            self.cli_config.python_package_manager.send_command(
                 "invenio",
                 "shell",
                 "--no-term-title",

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -84,16 +84,18 @@ class LocalCommands(Commands):
         Needed here (parent) because is used by Assets and Install commands.
         """
         # Commands
-        pkg_man = self.cli_config.python_package_manager
-        ops = [pkg_man.run_command("invenio", "collect", "--verbose")]
+        py_pkg_man = self.cli_config.python_package_manager
+
+        ops = [py_pkg_man.send_command("invenio", "collect", "--verbose")]
 
         if force:
-            ops.append(pkg_man.run_command("invenio", "webpack", "clean", "create"))
-            ops.append(pkg_man.run_command("invenio", "webpack", "install"))
+            ops.append(py_pkg_man.send_command("invenio", "webpack", "clean", "create"))
+            ops.append(py_pkg_man.send_command("invenio", "webpack", "install"))
         else:
-            ops.append(pkg_man.run_command("invenio", "webpack", "create"))
+            ops.append(py_pkg_man.send_command("invenio", "webpack", "create"))
         ops.append(self._statics)
-        ops.append(pkg_man.run_command("invenio", "webpack", "build"))
+        ops.append(py_pkg_man.send_command("invenio", "webpack", "build"))
+
         # Keep the same messages for some of the operations for backward compatibility
         messages = {
             "build": "Building assets...",

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019-2024 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
 # Copyright (C) 2021 Esteban J. G. Gabancho.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,6 +11,7 @@
 """Invenio-cli configuration file."""
 
 from configparser import ConfigParser
+from functools import cached_property
 from pathlib import Path
 
 from ..errors import InvenioCLIConfigError
@@ -62,7 +63,7 @@ class CLIConfig(object):
             with open(self.private_config_path) as cfg_file:
                 self.private_config.read_file(cfg_file)
 
-    @property
+    @cached_property
     def python_package_manager(self) -> PythonPackageManager:
         """Get python packages manager."""
         manager_name = self.config[CLIConfig.CLI_SECTION].get(


### PR DESCRIPTION
* use rpc-server which runs invenio commands

NOTE:

maybe it is not a good idea to use the rpc-server on all `run_command` calls e.g. `invenio-cli assets watch`