### PR TITLE
Noref/pyprojecttoml vesion check

### DIFF
--- a/invenio_cli/__init__.py
+++ b/invenio_cli/__init__.py
@@ -9,6 +9,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 __all__ = ("__version__",)

--- a/invenio_cli/helpers/rdm.py
+++ b/invenio_cli/helpers/rdm.py
@@ -21,22 +21,17 @@ def rdm_version():
     elif (cliConfig.project_path / "pyproject.toml").is_file():
         depfile = cliConfig.project_path / "pyproject.toml"
 
-    match = re.search(
-        r"invenio-app-rdm.*?==([\d.]+(?:b\d+)?(?:\.dev\d+)?)",
-        depfile.read_text(),
-    )
+    # find invenio-app-rdm line in either file
+    matchline = re.search(r"^.?invenio-app-rdm.*$", depfile.read_text(), re.MULTILINE)
+
+    # extract the version number of invenio-app-rdm
+    if matchline:
+        match = re.search(
+            r"[0-9]*\.[0-9]*\.[0-9]*",
+            matchline.group(0),
+        )
 
     if match:
-        print(match.group(1))
-        apprdmversion = []
-        for v in match.group(1).split("."):
-
-            try:
-                vs = int(v)
-                apprdmversion.append(vs)
-            except ValueError:
-                apprdmversion.append(v)
-        print("Invenio RDM version: ", apprdmversion)
-        return apprdmversion
+        return [int(v) for v in match.group(0).split(".")]
     else:
         return None

--- a/invenio_cli/helpers/rdm.py
+++ b/invenio_cli/helpers/rdm.py
@@ -10,19 +10,33 @@
 
 import re
 
-from pipfile import Pipfile
+from ..helpers.cli_config import CLIConfig
 
 
 def rdm_version():
     """Return the latest RDM version."""
-    parsed = Pipfile.load(filename="./Pipfile")
+    cliConfig = CLIConfig()
+    if (cliConfig.project_path / "Pipfile").is_file():
+        depfile = cliConfig.project_path / "Pipfile"
+    elif (cliConfig.project_path / "pyproject.toml").is_file():
+        depfile = cliConfig.project_path / "pyproject.toml"
 
-    groups = re.search(
-        r"[0-9]*\.[0-9]*\.[0-9]*",
-        parsed.data["default"].get("invenio-app-rdm", {}).get("version", ""),
+    match = re.search(
+        r"invenio-app-rdm.*?==([\d.]+(?:b\d+)?(?:\.dev\d+)?)",
+        depfile.read_text(),
     )
 
-    if groups:
-        return [int(v) for v in groups.group(0).split(".")]
+    if match:
+        print(match.group(1))
+        apprdmversion = []
+        for v in match.group(1).split("."):
+
+            try:
+                vs = int(v)
+                apprdmversion.append(vs)
+            except ValueError:
+                apprdmversion.append(v)
+        print("Invenio RDM version: ", apprdmversion)
+        return apprdmversion
     else:
         return None


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

After enabling users to use uv and pyproject.toml instead of pipenv and Pipfile `invenio-cli services setup` fails when no Pipfile is present anymore. This PR introduces a tooling-agnostic way of determining the app-rdm Version number from either Pipfile or pyproject.toml.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
