### PR TITLE
Fix accidental creation of a tuple in version check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version <next>
+
+- versions: fix accidental creation of a tuple from the version string
+
 Version 1.7.0 (released 2025-03-28)
 
 - build: allow use of either `npm` or `pnpm` as JS package manager (via `.invenio`)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@
 Changes
 =======
 
-Version <next>
+Version 1.7.1 (released 2025-03-31)
 
 - versions: fix accidental creation of a tuple from the version string
 

--- a/invenio_cli/__init__.py
+++ b/invenio_cli/__init__.py
@@ -9,6 +9,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 __all__ = ("__version__",)

--- a/invenio_cli/helpers/versions.py
+++ b/invenio_cli/helpers/versions.py
@@ -35,7 +35,7 @@ def _parse_version(version):
 def _from_pipfile(dep_name):
     """Parse the stated dependency from the ``Pipfile``."""
     parsed = Pipfile.load(filename="./Pipfile")
-    version = (parsed.data["default"].get(dep_name, {}).get("version", ""),)
+    version = parsed.data["default"].get(dep_name, {}).get("version", "")
     return _parse_version(version)
 
 


### PR DESCRIPTION
This fixes the `invenio-cli check-requirements` being broken when using `pipenv` (`Pipfile`).