### PR TITLE
fix: vi editing_mode when updating instance path

### DIFF
--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -42,6 +42,8 @@ class InstallCommands(LocalCommands):
             self.cli_config.python_package_manager.run_command(
                 "invenio",
                 "shell",
+                # make sure the shell does not append cursor if editing_mode is set to `vi` in config
+                "--TerminalInteractiveShell.editing_mode=''",
                 "--no-term-title",
                 "-c",
                 "\"print(app.instance_path, end='')\"",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR makes sure the instance path is updated correctly, even if the user has `editing_mode='vi'` set in their ipython config, so far resulting in funky instance paths like `.virtualenvs/mysite/var/instance$'\033'\[0\ q`, effectively breaking assets build.

Related issue: https://github.com/inveniosoftware/invenio-cli/issues/361

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
