### PR TITLE
fix(package_managers): use `--reinstall` flag for locked dependencies for `uv`

### DIFF
--- a/invenio_cli/helpers/package_managers.py
+++ b/invenio_cli/helpers/package_managers.py
@@ -152,7 +152,7 @@ class UV(PythonPackageManager):
 
     def install_locked_deps(self, prereleases, devtools):
         """Install the packages according to the lock file."""
-        cmd = [self.name, "sync"]
+        cmd = [self.name, "sync", "--reinstall"]
         if prereleases:
             cmd += ["--prerelease", "allow"]
         if not devtools:


### PR DESCRIPTION
* This is closer to the equivalent `pipenv sync` behaviour, which
  uninstalls packages that don't match exactly the state declared in the
  lockfile. This can be useful for users that relied on
  `invenio-cli install` for "resetting" their virtualenv dependencies.


> [!IMPORTANT]
> This is a tiny bit slower than just running `uv sync` in an already synced virtualenv, as it takes a couple of seconds vs. milliseconds. On the other hand, I don't think many folks run `invenio-cli install` that often after the first time.