### PR TITLE
fix: normalize paths in extracted translation files

### DIFF
--- a/tests/commands/test_translations.py
+++ b/tests/commands/test_translations.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+# Copyright (C) 2026 CESNET.
+#
+# Invenio-Cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for translations commands."""
+
+from pathlib import Path
+
+import pytest
+
+from invenio_cli.commands.translations import TranslationsCommands
+
+
+@pytest.fixture
+def temp_pot_file(tmp_path):
+    """Create a temporary .pot file with absolute paths."""
+    pot_file = tmp_path / "messages.pot"
+    pot_file.write_text(
+        "# Translations template\n"
+        "#, fuzzy\n"
+        'msgid ""\n'
+        'msgstr ""\n'
+        f"#: {tmp_path}/test.py:1\n"
+        'msgid "test message"\n'
+        'msgstr ""\n'
+    )
+    return pot_file
+
+
+def test_normalize_paths(temp_pot_file, tmp_path):
+    """Test that absolute paths are normalized to relative paths."""
+    commands = TranslationsCommands(cli_config=None, project_path=tmp_path)
+
+    commands._normalize_paths(str(temp_pot_file), tmp_path)
+    content = temp_pot_file.read_text()
+
+    assert str(tmp_path) not in content
+    assert "test.py:1" in content
+    assert "#: test.py:1" in content
+
+
+def test_normalize_paths_no_project_path(temp_pot_file, tmp_path):
+    """Test that normalization works when project_path is None."""
+    commands = TranslationsCommands(cli_config=None, project_path=None)
+    original_content = temp_pot_file.read_text()
+    commands._normalize_paths(str(temp_pot_file), None)
+
+    normalized_content = temp_pot_file.read_text()
+    assert original_content == normalized_content
+
+
+def test_normalize_paths_file_not_exists(tmp_path):
+    """Test that normalization handles non-existent files gracefully."""
+    commands = TranslationsCommands(cli_config=None, project_path=tmp_path)
+
+    # Run the normalization on a non-existent file - should not crash
+    commands._normalize_paths(str(tmp_path / "nonexistent.pot"), tmp_path)


### PR DESCRIPTION
## Description

This PR adds a path normalization step to the translation extraction process. When pybabel extracts messages from source code, it includes absolute file paths in the .pot file. This is problematic for shared translation templates because:

1. Absolute paths are machine-specific and break portability
2. They cause unnecessary diffs when different developers run extraction
3. They expose local filesystem structure

The fix adds a `_normalize_paths()` method that replaces absolute paths with relative paths by stripping the project path prefix from all file references in the .pot file. This ensures consistent, portable translation templates.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub's Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository's license.
2. You agree that you have the right to license your contribution under the current repository's license.