### PR TITLE
Enabling invenio-cli services setup inside k8s

### DIFF
--- a/invenio_cli/cli/services.py
+++ b/invenio_cli/cli/services.py
@@ -62,10 +62,13 @@ def setup(cli_config, force, no_demo_data, stop_services, services):
     """Setup local services."""
     # no_demo_data = False (default) means "YES to demo_data"
     demo_data = not no_demo_data
-    if not services:
-        docker_helper = NoOpDockerHelper()
-    else:
+    if services:
+        # use the default docker helper
         docker_helper = None
+    else:
+        # create a no-op docker helper as services are disabled
+        docker_helper = NoOpDockerHelper()
+
     commands = ServicesCommands(cli_config, docker_helper=docker_helper)
     steps = commands.setup(force, demo_data, stop_services, services)
     on_fail = "Failed to setup services."

--- a/invenio_cli/cli/services.py
+++ b/invenio_cli/cli/services.py
@@ -10,6 +10,7 @@
 import click
 
 from ..commands import ServicesCommands
+from ..helpers.docker_helper import NoOpDockerHelper
 from .utils import pass_cli_config, run_steps
 
 
@@ -61,7 +62,11 @@ def setup(cli_config, force, no_demo_data, stop_services, services):
     """Setup local services."""
     # no_demo_data = False (default) means "YES to demo_data"
     demo_data = not no_demo_data
-    commands = ServicesCommands(cli_config)
+    if not services:
+        docker_helper = NoOpDockerHelper()
+    else:
+        docker_helper = None
+    commands = ServicesCommands(cli_config, docker_helper=docker_helper)
     steps = commands.setup(force, demo_data, stop_services, services)
     on_fail = "Failed to setup services."
     on_success = "Successfully setup all services."

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -137,3 +137,30 @@ class DockerHelper(object):
                 output="Web UI container not found. Is it up and running?",
                 status_code=1,
             )
+
+
+class NoOpDockerHelper:
+    """A no-op implementation of DockerHelper that does nothing.
+
+    It is used when services can not be started with docker (e.g. in CI/CD environments)
+    and has the same interface as DockerHelper.
+    """
+
+    def build_images(self, pull=False, cache=True):
+        """Build images action. Not implemented in NoOpDockerHelper."""
+        raise NotImplementedError("Build images is not implemented in NoOpDockerHelper")
+
+    def start_containers(self, app_only=False):
+        """Start containers according to the specified environment.
+
+        :param app_only: Boot up only ui and api containers.
+        """
+        return ProcessResponse()
+
+    def stop_containers(self):
+        """Stop currently running containers."""
+        return ProcessResponse()
+
+    def destroy_containers(self):
+        """Stop and remove all containers, volumes and images."""
+        return ProcessResponse()


### PR DESCRIPTION
### Description

`invenio-cli services setup` currently can not be used in k8s, as it will try to instantiate a docker client even if `--no-services` is passed and the instantiation will fail. This happens inside the DockerHelper constructor where `self.docker_client = docker.from_env()` is called.

This PR fixes this issue by adding a NoOp implementation of DockerHelper that is used if `--no-services` are specified.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
