### PR TITLE
Add js lock file commands

### DIFF
--- a/invenio_cli/cli/assets.py
+++ b/invenio_cli/cli/assets.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -51,6 +51,14 @@ def build(cli_config, no_wipe, production, node_log_file):
         debug=not production,
         log_file=node_log_file,
     )
+
+
+@assets.command()
+@pass_cli_config
+def lock(cli_config):
+    """Create a lockfile for your assets."""
+    commands = AssetsCommands(cli_config)
+    commands.lock()
 
 
 @assets.command()

--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# Copyright (C) 2026 California Institute of Technology.
 # Copyright (C) 2020 CERN.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
@@ -8,6 +9,7 @@
 """Invenio module to ease the creation and management of applications."""
 
 from pathlib import Path
+from shutil import copyfile
 
 import click
 
@@ -74,6 +76,24 @@ class AssetsCommands(LocalCommands):
                 status_code=status_code,
             )
 
+    def _cache_js_lock_files(self):
+        """Cache js lock files."""
+        instance_path = self.cli_config.get_instance_path()
+        project_dir = self.cli_config.get_project_dir()
+
+        lock_file = self.cli_config.javascript_package_manager.lock_file_name
+        target_path = project_dir / lock_file
+        source_path = instance_path / "assets" / lock_file
+        if not source_path.is_symlink():
+            copyfile(source_path, target_path)
+
+        target_path = project_dir / "package.json"
+        source_path = instance_path / "assets" / "package.json"
+        if not source_path.is_symlink():
+            copyfile(source_path, target_path)
+
+        return ProcessResponse(output="Cached js lock files.", status_code=0)
+
     def watch_assets(self):
         """High-level command to watch assets for changes."""
         watch_cmd = self.cli_config.python_package_manager.run_command(
@@ -137,3 +157,35 @@ class AssetsCommands(LocalCommands):
         )
 
         return steps
+
+    def lock(self, debug=True, log_file=None):
+        """Lock assets."""
+        py_pkg_man = self.cli_config.python_package_manager
+        js_pkg_man = self.cli_config.javascript_package_manager
+
+        lock_arg = self.cli_config.javascript_package_manager.lock_dependencies()
+
+        ops = [py_pkg_man.run_command("invenio", "collect", "--verbose")]
+        ops.append(py_pkg_man.run_command("invenio", "webpack", "clean", "create"))
+        lock_args = ["invenio", "webpack", "install"] + lock_arg
+        ops.append(py_pkg_man.run_command(*lock_args))
+        ops.append(self._cache_js_lock_files)
+        messages = {
+            "build": "Locking assets...",
+        }
+
+        with env(FLASK_DEBUG="1" if debug else "0"):
+            for op in ops:
+                if callable(op):
+                    response = op()
+                else:
+                    if op[-1] in messages:
+                        click.secho(messages[op[-1]], fg="green")
+                    response = run_interactive(
+                        op,
+                        env={"PIPENV_VERBOSITY": "-1", **js_pkg_man.env_overrides()},
+                        log_file=log_file,
+                    )
+                if response.status_code != 0:
+                    break
+        return response

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -11,8 +11,9 @@
 import os
 import signal
 from distutils.dir_util import copy_tree
-from os import environ
+from os import environ, symlink
 from pathlib import Path
+from shutil import copyfile
 from subprocess import Popen as popen
 
 import click
@@ -79,6 +80,41 @@ class LocalCommands(Commands):
             status_code=0,
         )
 
+    def _symlink_locked_file(self):
+        """Symlink locked file."""
+        instance_path = self.cli_config.get_instance_path()
+        project_dir = self.cli_config.get_project_dir()
+
+        if self.cli_config.javascript_package_manager.name == "npm":
+            lock_file = "packages-lock.json"
+        elif self.cli_config.javascript_package_manager.name == "pnpm":
+            lock_file = "pnpm-lock.yaml"
+
+        source_path = project_dir / lock_file
+        target_path = instance_path / "assets" / lock_file
+
+        if Path(source_path).exists():
+            symlink(source_path, target_path)
+
+        return ProcessResponse(output="Symlinked locked file.", status_code=0)
+
+    def _cache_locked_file(self):
+        """Cache locked file."""
+        instance_path = self.cli_config.get_instance_path()
+        project_dir = self.cli_config.get_project_dir()
+
+        if self.cli_config.javascript_package_manager.name == "npm":
+            lock_file = "packages-lock.json"
+        elif self.cli_config.javascript_package_manager.name == "pnpm":
+            lock_file = "pnpm-lock.yaml"
+
+        target_path = project_dir / lock_file
+        source_path = instance_path / "assets" / lock_file
+        if not source_path.is_symlink():
+            copyfile(source_path, target_path)
+
+        return ProcessResponse(output="Cached locked file.", status_code=0)
+
     def update_statics_and_assets(self, force, debug=False, log_file=None):
         """High-level command to update less/js/images/... files.
 
@@ -91,11 +127,14 @@ class LocalCommands(Commands):
 
         if force:
             ops.append(py_pkg_man.run_command("invenio", "webpack", "clean", "create"))
+            ops.append(self._symlink_locked_file)
             ops.append(py_pkg_man.run_command("invenio", "webpack", "install"))
         else:
             ops.append(py_pkg_man.run_command("invenio", "webpack", "create"))
         ops.append(self._statics)
         ops.append(py_pkg_man.run_command("invenio", "webpack", "build"))
+        ops.append(self._cache_locked_file)
+
         # Keep the same messages for some of the operations for backward compatibility
         messages = {
             "build": "Building assets...",

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# Copyright (C) 2026 California Institute of Technology.
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2022 Graz University of Technology.
 #
@@ -11,7 +12,7 @@
 import os
 import signal
 from distutils.dir_util import copy_tree
-from os import environ, symlink
+from os import environ
 from pathlib import Path
 from shutil import copyfile
 from subprocess import Popen as popen
@@ -80,40 +81,25 @@ class LocalCommands(Commands):
             status_code=0,
         )
 
-    def _symlink_locked_file(self):
-        """Symlink locked file."""
+    def _copy_js_lock_files(self):
+        """Copy js lock files."""
         instance_path = self.cli_config.get_instance_path()
         project_dir = self.cli_config.get_project_dir()
 
-        if self.cli_config.javascript_package_manager.name == "npm":
-            lock_file = "packages-lock.json"
-        elif self.cli_config.javascript_package_manager.name == "pnpm":
-            lock_file = "pnpm-lock.yaml"
-
+        lock_file = self.cli_config.javascript_package_manager.lock_file_name
         source_path = project_dir / lock_file
         target_path = instance_path / "assets" / lock_file
-
         if Path(source_path).exists():
-            symlink(source_path, target_path)
-
-        return ProcessResponse(output="Symlinked locked file.", status_code=0)
-
-    def _cache_locked_file(self):
-        """Cache locked file."""
-        instance_path = self.cli_config.get_instance_path()
-        project_dir = self.cli_config.get_project_dir()
-
-        if self.cli_config.javascript_package_manager.name == "npm":
-            lock_file = "packages-lock.json"
-        elif self.cli_config.javascript_package_manager.name == "pnpm":
-            lock_file = "pnpm-lock.yaml"
-
-        target_path = project_dir / lock_file
-        source_path = instance_path / "assets" / lock_file
-        if not source_path.is_symlink():
             copyfile(source_path, target_path)
 
-        return ProcessResponse(output="Cached locked file.", status_code=0)
+        source_path = project_dir / "package.json"
+        target_path = instance_path / "assets" / "package.json"
+        if Path(source_path).exists():
+            copyfile(source_path, target_path)
+
+        return ProcessResponse(
+            output="Copied js lock files to instance.", status_code=0
+        )
 
     def update_statics_and_assets(self, force, debug=False, log_file=None):
         """High-level command to update less/js/images/... files.
@@ -127,13 +113,17 @@ class LocalCommands(Commands):
 
         if force:
             ops.append(py_pkg_man.run_command("invenio", "webpack", "clean", "create"))
-            ops.append(self._symlink_locked_file)
+            # We need to copy the js lock files here, since webpack regenerates
+            # package.json and we want the locked version instead.
+            ops.append(self._copy_js_lock_files)
             ops.append(py_pkg_man.run_command("invenio", "webpack", "install"))
         else:
             ops.append(py_pkg_man.run_command("invenio", "webpack", "create"))
+            # We need to copy the js lock files here, since webpack regenerates
+            # package.json and we want the locked version instead.
+            ops.append(self._copy_js_lock_files)
         ops.append(self._statics)
         ops.append(py_pkg_man.run_command("invenio", "webpack", "build"))
-        ops.append(self._cache_locked_file)
 
         # Keep the same messages for some of the operations for backward compatibility
         messages = {

--- a/invenio_cli/helpers/package_managers.py
+++ b/invenio_cli/helpers/package_managers.py
@@ -192,6 +192,7 @@ class JavascriptPackageManager(ABC):
     """Interface for creating tool-specific JS package management commands."""
 
     name = None
+    lock_file_name = None
 
     def create_pynpm_package(self, package_json_path: Union[Path, str]) -> NPMPackage:
         """Create a variant of ``NPMPackage`` with the path to ``package.json``."""
@@ -209,11 +210,16 @@ class JavascriptPackageManager(ABC):
         """Generate steps to link the target package to the project."""
         raise NotImplementedError()
 
+    def lock_dependencies(self) -> List[str]:
+        """Update the lock file."""
+        raise NotImplementedError()
+
 
 class NPM(JavascriptPackageManager):
     """Generate ``npm`` commands for managing JS packages."""
 
     name = "npm"
+    lock_file_name = "package-lock.json"
 
     def create_pynpm_package(self, package_json_path):
         """Create an ``NPMPackage`` with the path to ``package.json``."""
@@ -222,6 +228,10 @@ class NPM(JavascriptPackageManager):
     def install_local_package(self, path):
         """Install the local JS package."""
         return ["--prefix", str(path)]
+
+    def lock_dependencies(self):
+        """Lock the JS package."""
+        return ["--package-lock-only", "--ignore-scripts"]
 
     def env_overrides(self):
         """Provide environment overrides for building Invenio assets."""
@@ -278,6 +288,7 @@ class PNPM(JavascriptPackageManager):
     """Generate ``pnpm`` commands for managing JS packages."""
 
     name = "pnpm"
+    lock_file_name = "pnpm-lock.yaml"
 
     def create_pynpm_package(self, package_json_path):
         """Create a ``PNPMPackage`` with the path to ``package.json``."""
@@ -286,6 +297,10 @@ class PNPM(JavascriptPackageManager):
     def install_local_package(self, path):
         """Install the local JS package."""
         return ["-C", str(path)]
+
+    def lock_dependencies(self):
+        """Lock the JS package."""
+        return ["--lockfile-only"]
 
     def env_overrides(self):
         """Provide environment overrides for building Invenio assets."""


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR builds off of some commits in https://github.com/inveniosoftware/invenio-cli/pull/390

At the moment, invenio-cli will wipe and recreate all js assets when runming the `invenio-cli install` command. This isn't the most safe thing to do in a world of package compromises. This PR attempts to recommend a new workflow, where a command `invenio-cli assets lock` will create a packages.json and package-lock.json`, which can be committed into a repository. Then the assets build commands use those locked dependencies when reinstalling. This makes the js behavior more similar to how the python behavior works (respecting a lock file), without changing the default if a lock file isn't present.

I haven't tested on pnpm, though support should be included.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
