### PR TITLE
dont override site api ui url by run

### DIFF
--- a/invenio_cli/cli/cli.py
+++ b/invenio_cli/cli/cli.py
@@ -149,22 +149,6 @@ def init(flavour, template, checkout, user_input, config):
         cookiecutter_wrapper.remove_config()
 
 
-@invenio_cli.group("run", invoke_without_command=True)
-@click.pass_context
-def run_group(ctx):
-    """Run command group."""
-    # For backward compatibility
-    if ctx.invoked_subcommand is None:
-        ctx.invoke(run_all)
-
-
-services_option = click.option(
-    "--services/--no-services",
-    "-s/-n",
-    default=True,
-    is_flag=True,
-    help="Enable/disable dockerized services (default: enabled).",
-)
 web_options = combine_decorators(
     click.option(
         "--host",
@@ -188,25 +172,13 @@ web_options = combine_decorators(
 )
 
 
-@run_group.command("web")
-@services_option
-@web_options
-@pass_cli_config
-def run_web(cli_config, host, port, debug, services):
-    """Starts the local development web server."""
-    if services:
-        cmds = ServicesCommands(cli_config)
-        response = cmds.ensure_containers_running()
-        # fail and exit if containers are not running
-        handle_process_response(response)
-
-    host = host or cli_config.get_web_host()
-    port = port or cli_config.get_web_port()
-
-    commands = LocalCommands(cli_config)
-    processes = commands.run_web(host=host, port=str(port), debug=debug)
-    for proc in processes:
-        proc.wait()
+services_option = click.option(
+    "--services/--no-services",
+    "-s/-n",
+    default=True,
+    is_flag=True,
+    help="Enable/disable dockerized services (default: enabled).",
+)
 
 
 worker_options = combine_decorators(
@@ -226,6 +198,40 @@ worker_options = combine_decorators(
         help="Enable/disable separate jobs scheduler (default: enabled)",
     ),
 )
+
+
+@invenio_cli.group("run", invoke_without_command=True)
+@web_options  # this and below for backwards-compatibility
+@services_option
+@worker_options
+@pass_cli_config
+@click.pass_context
+def run_group(ctx, *args, **kwargs):
+    """Run command group."""
+    # For backward compatibility
+    if ctx.invoked_subcommand is None:
+        ctx.forward(run_all)
+
+
+@run_group.command("web")
+@services_option
+@web_options
+@pass_cli_config
+def run_web(cli_config, host, port, debug, services):
+    """Starts the local development web server."""
+    if services:
+        cmds = ServicesCommands(cli_config)
+        response = cmds.ensure_containers_running()
+        # fail and exit if containers are not running
+        handle_process_response(response)
+
+    host = host or cli_config.get_web_host()
+    port = port or cli_config.get_web_port()
+
+    commands = LocalCommands(cli_config)
+    processes = commands.run_web(host=host, port=str(port), debug=debug)
+    for proc in processes:
+        proc.wait()
 
 
 @run_group.command("worker")

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2026 California Institute of Technology.
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2026 Northwestern University.
 #
 # Invenio-Cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -165,8 +166,6 @@ class LocalCommands(Commands):
         click.secho("Starting up local (development) server...", fg="green")
         run_env = environ.copy()
         run_env["FLASK_DEBUG"] = "1" if debug else "0"
-        run_env["INVENIO_SITE_UI_URL"] = f"https://{host}:{port}"
-        run_env["INVENIO_SITE_API_URL"] = f"https://{host}:{port}/api"
         pkg_man = self.cli_config.python_package_manager
         proc = popen(
             pkg_man.run_command(


### PR DESCRIPTION
- **fix(run): don't override SITE_API/UI_URL settings with listening hosts/port [+]**
  * discussed at maintainer call and on discord
  * closes https://github.com/inveniosoftware/invenio-cli/issues/202
  * I think it would close https://github.com/inveniosoftware/invenio-app-rdm/issues/3439 too because then it sets SITE_API_URL to use 0.0.0.0 (@zahnwiegebiss if you want to take a look)
- **fix(run): keep invenio-cli run [OPTIONS] backwards compatibility**
  * closes https://github.com/inveniosoftware/docs-invenio-rdm/issues/930
  * `invenio-cli run --host X.X.X.X --port ...` is now again possible as before
  * `invenio-cli run all --host ...` also works
  * `invenio-cli run --host ... all/web` does not, but that's the click "default" and that CLI interface was never promised, so I think it's fair to let it like this