### PR TITLE
Add RPC server support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,12 +79,11 @@ It is possible to choose between two assets builders: `webpack` and `rspack`.
 `webpack` is the default one. To use `rspack` add `WEBPACKEXT_PROJECT =
 "invenio_assets.webpack:rspack_project"` to the `invenio.cfg` file.
 
-It is possible to use a long running invenio rpc-server by starting it with
-`invenio rpc-server start --port 5001`. This should only be done if you know the
-drawbacks. The server has to be restarted if code which the server uses has been
-updated. Further it is not necessary to use a long running invenio rpc-server
-since it will be started on every invenio-cli command a new rpc-server
-nevertheless if no rpc-server runs already.
+It is possible to send `invenio` commands to a long running RPC server instead
+of starting a new Python process for each command. To enable this add the line
+`use_rpc = true` to the `[cli]` section of the `.invenio` file. The server
+listens on a Unix domain socket at `<instance_path>/rpc.sock` and is started
+automatically when needed; invenio-cli stops it again on exit.
 
 The javascript package manager uses a lock file like the python package manager.
 This file `pnpm-lock.yaml` for `pnpm` and `packages-lock.json` for `npm` will be
@@ -110,7 +109,7 @@ existing in the same directory as the `pyproject.toml` file.
 
 UV uses a `pyproject.toml` file.
 
-`rcp-server`
+`rpc-server`
 
 To use `pnpm` with the `rpc-server` it is necessary to add
 `WEBPACKEXT_NPM_PKG_CLS = "pynpm:PNPMPackage"` to the `invenio.cfg` file.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 ..
     SPDX-FileCopyrightText: 2019-2020 CERN.
     SPDX-FileCopyrightText: 2019-2020 Northwestern University.
+    SPDX-FileCopyrightText: 2025 Graz University of Technology.
     SPDX-License-Identifier: MIT
 
 =================
@@ -60,6 +61,59 @@ Local Development environment
 
     # Update assets or statics
     $ invenio-cli update
+
+Customizations
+==============
+
+It is possible to choose between two python package managers: `pipenv` and `uv`.
+`pipenv` is the default one. To customize the python package manager it is
+necessary to add the line `python_package_manager = VALUE` to the `.invenio`
+file. `VALUE` is `uv` or `pipenv`.
+
+It is possible to choose between two javascript package managers: `npm` and
+`pnpm`. `npm` is the default one. To customize the python package manager it is
+necessary to add the line `javascript_package_manager = VALUE` to the `.invenio`
+file. `VALUE` is `npm` or `pnpm`.
+
+It is possible to choose between two assets builders: `webpack` and `rspack`.
+`webpack` is the default one. To use `rspack` add `WEBPACKEXT_PROJECT =
+"invenio_assets.webpack:rspack_project"` to the `invenio.cfg` file.
+
+It is possible to use a long running invenio rpc-server by starting it with
+`invenio rpc-server start --port 5001`. This should only be done if you know the
+drawbacks. The server has to be restarted if code which the server uses has been
+updated. Further it is not necessary to use a long running invenio rpc-server
+since it will be started on every invenio-cli command a new rpc-server
+nevertheless if no rpc-server runs already.
+
+The javascript package manager uses a lock file like the python package manager.
+This file `pnpm-lock.yaml` for `pnpm` and `packages-lock.json` for `npm` will be
+symlinked to the `var/instance/assets/` directory.
+
+Hints
+=====
+
+`uv`
+
+The development with `uv` is a little bit different than with `pipenv`. If there
+is a `uv.lock` file packages have to be updated manually or by removing the
+`uv.lock` file. The absence of the `uv.lock` file triggeres a new dependency
+resolving call which takes into account of new released packages. It would also
+be possible to use the `uv sync --upgrade` feature of `uv` but this installs
+also beta versions of packages which is not recommended. It may sound strange to
+remove the `uv.lock` file, but `uv` is that fast that deleting the `.venv`
+directory and the `uv.lock` file is the easiest and fastest and safest way to
+upgrade the packages.
+
+UV uses a local `.venv` directory. This will be created automatically, if not
+existing in the same directory as the `pyproject.toml` file.
+
+UV uses a `pyproject.toml` file.
+
+`rcp-server`
+
+To use `pnpm` with the `rpc-server` it is necessary to add
+`WEBPACKEXT_NPM_PKG_CLS = "pynpm:PNPMPackage"` to the `invenio.cfg` file.
 
 
 Containerized 'Production' environment

--- a/invenio_cli/commands/assets.py
+++ b/invenio_cli/commands/assets.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 California Institute of Technology.
 # SPDX-FileCopyrightText: 2020 CERN.
+# SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Invenio module to ease the creation and management of applications."""

--- a/invenio_cli/commands/containers.py
+++ b/invenio_cli/commands/containers.py
@@ -137,7 +137,7 @@ class ContainersCommands(ServicesCommands):
             ),
         ]
 
-        if rdm_version()[0] >= 10:
+        if rdm_version(self.cli_config)[0] >= 10:
             steps.extend(
                 [
                     FunctionStep(
@@ -159,11 +159,11 @@ class ContainersCommands(ServicesCommands):
                 ]
             )
 
-        if rdm_version()[0] >= 11:
+        if rdm_version(self.cli_config)[0] >= 11:
             steps.extend(self.rdm_fixtures(project_shortname))
             steps.extend(self.translations(project_shortname))
 
-        if rdm_version()[0] >= 12:
+        if rdm_version(self.cli_config)[0] >= 12:
             steps.extend(self.declare_queues(project_shortname))
 
         return steps

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -34,7 +34,7 @@ class InstallCommands(LocalCommands):
     def update_instance_path(self):
         """Update path to instance in config."""
         result = run_cmd(
-            self.cli_config.python_package_manager.run_command(
+            self.cli_config.python_package_manager.send_command(
                 "invenio",
                 "shell",
                 # make sure the shell does not append cursor if editing_mode is set to `vi` in config

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -5,7 +5,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 from ..helpers import filesystem
-from ..helpers.process import run_cmd
 from .local import LocalCommands
 from .packages import PackagesCommands
 from .steps import FunctionStep
@@ -33,7 +32,7 @@ class InstallCommands(LocalCommands):
 
     def update_instance_path(self):
         """Update path to instance in config."""
-        op = self.cli_config.python_package_manager.send_command(
+        op = self.cli_config.python_package_manager.invenio_command(
             "invenio",
             "shell",
             # make sure the shell does not append cursor if editing_mode is set to `vi` in config
@@ -42,7 +41,7 @@ class InstallCommands(LocalCommands):
             "-c",
             "print(app.instance_path, end='')",
         )
-        result = op() if callable(op) else run_cmd(op)
+        result = op(capture=True)
         if result.status_code == 0:
             self.cli_config.update_instance_path(result.output.strip())
             result.output = "Instance path updated successfully."

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -33,17 +33,16 @@ class InstallCommands(LocalCommands):
 
     def update_instance_path(self):
         """Update path to instance in config."""
-        result = run_cmd(
-            self.cli_config.python_package_manager.send_command(
-                "invenio",
-                "shell",
-                # make sure the shell does not append cursor if editing_mode is set to `vi` in config
-                "--TerminalInteractiveShell.editing_mode=''",
-                "--no-term-title",
-                "-c",
-                "print(app.instance_path, end='')",
-            )
+        op = self.cli_config.python_package_manager.send_command(
+            "invenio",
+            "shell",
+            # make sure the shell does not append cursor if editing_mode is set to `vi` in config
+            "--TerminalInteractiveShell.editing_mode=''",
+            "--no-term-title",
+            "-c",
+            "print(app.instance_path, end='')",
         )
+        result = op() if callable(op) else run_cmd(op)
         if result.status_code == 0:
             self.cli_config.update_instance_path(result.output.strip())
             result.output = "Instance path updated successfully."

--- a/invenio_cli/commands/install.py
+++ b/invenio_cli/commands/install.py
@@ -41,7 +41,7 @@ class InstallCommands(LocalCommands):
                 "--TerminalInteractiveShell.editing_mode=''",
                 "--no-term-title",
                 "-c",
-                "\"print(app.instance_path, end='')\"",
+                "print(app.instance_path, end='')",
             )
         )
         if result.status_code == 0:

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -224,7 +224,7 @@ class LocalCommands(Commands):
     def run_jobs_scheduler(self, celery_log_file=None, celery_log_level="INFO"):
         """Run Celery beat scheduler for jobs."""
         # Jobs scheduler is only available in RDM v13+
-        version = rdm_version()
+        version = rdm_version(self.cli_config)
         if version is None:
             click.secho(
                 "RDM version couldn't be determined. Not running jobs scheduler.",

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -17,8 +17,9 @@ from subprocess import Popen as popen
 import click
 
 from ..helpers import env, filesystem
-from ..helpers.process import ProcessResponse, run_interactive
-from ..helpers.rpc import RPCCall, echo_output
+from ..helpers.package_managers import LocalOp
+from ..helpers.process import ProcessResponse
+from ..helpers.rpc import RPCOp
 from ..helpers.versions import rdm_version
 from .commands import Commands
 
@@ -107,19 +108,21 @@ class LocalCommands(Commands):
         # Commands
         py_pkg_man = self.cli_config.python_package_manager
         js_pkg_man = self.cli_config.javascript_package_manager
-        ops = [py_pkg_man.send_command("invenio", "collect", "--verbose")]
+        ops = [py_pkg_man.invenio_command("invenio", "collect", "--verbose")]
 
         if force:
-            ops.append(py_pkg_man.send_command("invenio", "webpack", "clean", "create"))
+            ops.append(
+                py_pkg_man.invenio_command("invenio", "webpack", "clean", "create")
+            )
             # We need to copy the js lock files here, since webpack regenerates
             # package.json and we want the locked version instead.
             ops.append(self._copy_js_lock_files)
-            ops.append(py_pkg_man.send_command("invenio", "webpack", "install"))
+            ops.append(py_pkg_man.invenio_command("invenio", "webpack", "install"))
         else:
-            ops.append(py_pkg_man.send_command("invenio", "webpack", "create"))
+            ops.append(py_pkg_man.invenio_command("invenio", "webpack", "create"))
             ops.append(self._copy_js_lock_files)
         ops.append(self._statics)
-        ops.append(py_pkg_man.send_command("invenio", "webpack", "build"))
+        ops.append(py_pkg_man.invenio_command("invenio", "webpack", "build"))
         # Keep the same messages for some of the operations for backward compatibility
         messages = {
             "build": "Building assets...",
@@ -128,21 +131,15 @@ class LocalCommands(Commands):
 
         with env(FLASK_DEBUG="1" if debug else "0"):
             for op in ops:
-                if isinstance(op, RPCCall):
+                if isinstance(op, (LocalOp, RPCOp)):
                     if op.label in messages:
                         click.secho(messages[op.label], fg="green")
-                    response = op()
-                    echo_output(response, log_file=log_file)
-                elif callable(op):
-                    response = op()
-                else:
-                    if op[-1] in messages:
-                        click.secho(messages[op[-1]], fg="green")
-                    response = run_interactive(
-                        op,
+                    response = op(
                         env={"PIPENV_VERBOSITY": "-1", **js_pkg_man.env_overrides()},
                         log_file=log_file,
                     )
+                else:
+                    response = op()
                 if response.status_code != 0:
                     break
         return response

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -18,7 +18,7 @@ import click
 
 from ..helpers import env, filesystem
 from ..helpers.process import ProcessResponse, run_interactive
-from ..helpers.rpc import RPCCall
+from ..helpers.rpc import RPCCall, echo_output
 from ..helpers.versions import rdm_version
 from .commands import Commands
 
@@ -132,17 +132,7 @@ class LocalCommands(Commands):
                     if op.label in messages:
                         click.secho(messages[op.label], fg="green")
                     response = op()
-                    # the server buffers Python-level output; surface it the
-                    # same way a locally run command would
-                    if log_file:
-                        with open(log_file, "a") as f:
-                            f.write(response.output or "")
-                            f.write(response.error or "")
-                    else:
-                        if response.output:
-                            click.echo(response.output, nl=False)
-                        if response.error:
-                            click.echo(response.error, nl=False, err=True)
+                    echo_output(response, log_file=log_file)
                 elif callable(op):
                     response = op()
                 else:

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -18,6 +18,7 @@ import click
 
 from ..helpers import env, filesystem
 from ..helpers.process import ProcessResponse, run_interactive
+from ..helpers.rpc import RPCCall
 from ..helpers.versions import rdm_version
 from .commands import Commands
 
@@ -127,7 +128,22 @@ class LocalCommands(Commands):
 
         with env(FLASK_DEBUG="1" if debug else "0"):
             for op in ops:
-                if callable(op):
+                if isinstance(op, RPCCall):
+                    if op.label in messages:
+                        click.secho(messages[op.label], fg="green")
+                    response = op()
+                    # the server buffers Python-level output; surface it the
+                    # same way a locally run command would
+                    if log_file:
+                        with open(log_file, "a") as f:
+                            f.write(response.output or "")
+                            f.write(response.error or "")
+                    else:
+                        if response.output:
+                            click.echo(response.output, nl=False)
+                        if response.error:
+                            click.echo(response.error, nl=False, err=True)
+                elif callable(op):
                     response = op()
                 else:
                     if op[-1] in messages:

--- a/invenio_cli/commands/local.py
+++ b/invenio_cli/commands/local.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2026 California Institute of Technology.
 # SPDX-FileCopyrightText: 2020 CERN.
-# SPDX-FileCopyrightText: 2022 Graz University of Technology.
+# SPDX-FileCopyrightText: 2022-2026 Graz University of Technology.
 # SPDX-FileCopyrightText: 2026 Northwestern University.
 # SPDX-License-Identifier: MIT
 
@@ -106,22 +106,19 @@ class LocalCommands(Commands):
         # Commands
         py_pkg_man = self.cli_config.python_package_manager
         js_pkg_man = self.cli_config.javascript_package_manager
-        ops = [py_pkg_man.run_command("invenio", "collect", "--verbose")]
+        ops = [py_pkg_man.send_command("invenio", "collect", "--verbose")]
 
         if force:
-            ops.append(py_pkg_man.run_command("invenio", "webpack", "clean", "create"))
+            ops.append(py_pkg_man.send_command("invenio", "webpack", "clean", "create"))
             # We need to copy the js lock files here, since webpack regenerates
             # package.json and we want the locked version instead.
             ops.append(self._copy_js_lock_files)
-            ops.append(py_pkg_man.run_command("invenio", "webpack", "install"))
+            ops.append(py_pkg_man.send_command("invenio", "webpack", "install"))
         else:
-            ops.append(py_pkg_man.run_command("invenio", "webpack", "create"))
-            # We need to copy the js lock files here, since webpack regenerates
-            # package.json and we want the locked version instead.
+            ops.append(py_pkg_man.send_command("invenio", "webpack", "create"))
             ops.append(self._copy_js_lock_files)
         ops.append(self._statics)
-        ops.append(py_pkg_man.run_command("invenio", "webpack", "build"))
-
+        ops.append(py_pkg_man.send_command("invenio", "webpack", "build"))
         # Keep the same messages for some of the operations for backward compatibility
         messages = {
             "build": "Building assets...",

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -84,7 +84,7 @@ class ServicesCommands(Commands):
         pkg_man = self.cli_config.python_package_manager
         steps = [
             CommandStep(
-                cmd=pkg_man.send_command(
+                cmd=pkg_man.invenio_command(
                     "invenio",
                     "shell",
                     "--no-term-title",
@@ -96,13 +96,13 @@ class ServicesCommands(Commands):
                 skippable=True,
             ),
             CommandStep(
-                cmd=pkg_man.send_command("invenio", "db", "destroy", "--yes-i-know"),
+                cmd=pkg_man.invenio_command("invenio", "db", "destroy", "--yes-i-know"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Destroying database...",
                 skippable=True,
             ),
             CommandStep(
-                cmd=pkg_man.send_command(
+                cmd=pkg_man.invenio_command(
                     "invenio",
                     "index",
                     "destroy",
@@ -114,7 +114,9 @@ class ServicesCommands(Commands):
                 skippable=True,
             ),
             CommandStep(
-                cmd=pkg_man.send_command("invenio", "index", "queue", "init", "purge"),
+                cmd=pkg_man.invenio_command(
+                    "invenio", "index", "queue", "init", "purge"
+                ),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Purging queues...",
                 skippable=True,
@@ -145,12 +147,12 @@ class ServicesCommands(Commands):
                 message="Checking services are not setup...",
             ),
             CommandStep(
-                cmd=pkg_man.send_command("invenio", "db", "init", "create"),
+                cmd=pkg_man.invenio_command("invenio", "db", "init", "create"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating database...",
             ),
             CommandStep(
-                cmd=pkg_man.send_command(
+                cmd=pkg_man.invenio_command(
                     "invenio",
                     "files",
                     "location",
@@ -163,12 +165,12 @@ class ServicesCommands(Commands):
                 message="Creating files location...",
             ),
             CommandStep(
-                cmd=pkg_man.send_command("invenio", "roles", "create", "admin"),
+                cmd=pkg_man.invenio_command("invenio", "roles", "create", "admin"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating admin role...",
             ),
             CommandStep(
-                cmd=pkg_man.send_command(
+                cmd=pkg_man.invenio_command(
                     "invenio",
                     "access",
                     "allow",
@@ -180,7 +182,7 @@ class ServicesCommands(Commands):
                 message="Allowing superuser access to admin role...",
             ),
             CommandStep(
-                cmd=pkg_man.send_command("invenio", "index", "init"),
+                cmd=pkg_man.invenio_command("invenio", "index", "init"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating indices...",
             ),
@@ -192,7 +194,7 @@ class ServicesCommands(Commands):
                 steps.extend(
                     [
                         CommandStep(
-                            cmd=pkg_man.send_command(
+                            cmd=pkg_man.invenio_command(
                                 "invenio",
                                 "rdm-records",
                                 "custom-fields",
@@ -202,7 +204,7 @@ class ServicesCommands(Commands):
                             message="Creating custom fields for records...",
                         ),
                         CommandStep(
-                            cmd=pkg_man.send_command(
+                            cmd=pkg_man.invenio_command(
                                 "invenio",
                                 "communities",
                                 "custom-fields",
@@ -235,7 +237,7 @@ class ServicesCommands(Commands):
             args = ["invenio", "setup", "--verbose"]
             if not demo_data:
                 args.append("--skip-demo-data")
-            cmd = pkg_man.send_command(*args)
+            cmd = pkg_man.invenio_command(*args)
             steps.extend(
                 [
                     CommandStep(
@@ -261,7 +263,7 @@ class ServicesCommands(Commands):
         pkg_man = self.cli_config.python_package_manager
         steps = [
             CommandStep(
-                cmd=pkg_man.send_command("invenio", "rdm-records", "demo"),
+                cmd=pkg_man.invenio_command("invenio", "rdm-records", "demo"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating demo records...",
             )
@@ -272,14 +274,14 @@ class ServicesCommands(Commands):
     def declare_queues(self):
         """Steps to declare the MQ queues required for statistics, etc."""
         pkg_man = self.cli_config.python_package_manager
-        command = pkg_man.send_command("invenio", "queues", "declare")
+        command = pkg_man.invenio_command("invenio", "queues", "declare")
         steps = [CommandStep(cmd=command, message="Declaring queues...")]
         return steps
 
     def fixtures(self):
         """Steps to set up the required fixtures for the instance."""
         pkg_man = self.cli_config.python_package_manager
-        command = pkg_man.send_command("invenio", "rdm-records", "fixtures")
+        command = pkg_man.invenio_command("invenio", "rdm-records", "fixtures")
         steps = [
             CommandStep(
                 cmd=command,
@@ -293,7 +295,7 @@ class ServicesCommands(Commands):
     def rdm_fixtures(self):
         """Steps to set up the rdm fixtures for the instance."""
         pkg_man = self.cli_config.python_package_manager
-        command = pkg_man.send_command("invenio", "rdm", "fixtures")
+        command = pkg_man.invenio_command("invenio", "rdm", "fixtures")
         steps = [
             CommandStep(
                 cmd=command,

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -84,7 +84,7 @@ class ServicesCommands(Commands):
         pkg_man = self.cli_config.python_package_manager
         steps = [
             CommandStep(
-                cmd=pkg_man.run_command(
+                cmd=pkg_man.send_command(
                     "invenio",
                     "shell",
                     "--no-term-title",
@@ -96,13 +96,13 @@ class ServicesCommands(Commands):
                 skippable=True,
             ),
             CommandStep(
-                cmd=pkg_man.run_command("invenio", "db", "destroy", "--yes-i-know"),
+                cmd=pkg_man.send_command("invenio", "db", "destroy", "--yes-i-know"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Destroying database...",
                 skippable=True,
             ),
             CommandStep(
-                cmd=pkg_man.run_command(
+                cmd=pkg_man.send_command(
                     "invenio",
                     "index",
                     "destroy",
@@ -114,7 +114,7 @@ class ServicesCommands(Commands):
                 skippable=True,
             ),
             CommandStep(
-                cmd=pkg_man.run_command("invenio", "index", "queue", "init", "purge"),
+                cmd=pkg_man.send_command("invenio", "index", "queue", "init", "purge"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Purging queues...",
                 skippable=True,
@@ -145,12 +145,12 @@ class ServicesCommands(Commands):
                 message="Checking services are not setup...",
             ),
             CommandStep(
-                cmd=pkg_man.run_command("invenio", "db", "init", "create"),
+                cmd=pkg_man.send_command("invenio", "db", "init", "create"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating database...",
             ),
             CommandStep(
-                cmd=pkg_man.run_command(
+                cmd=pkg_man.send_command(
                     "invenio",
                     "files",
                     "location",
@@ -163,12 +163,12 @@ class ServicesCommands(Commands):
                 message="Creating files location...",
             ),
             CommandStep(
-                cmd=pkg_man.run_command("invenio", "roles", "create", "admin"),
+                cmd=pkg_man.send_command("invenio", "roles", "create", "admin"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating admin role...",
             ),
             CommandStep(
-                cmd=pkg_man.run_command(
+                cmd=pkg_man.send_command(
                     "invenio",
                     "access",
                     "allow",
@@ -180,7 +180,7 @@ class ServicesCommands(Commands):
                 message="Allowing superuser access to admin role...",
             ),
             CommandStep(
-                cmd=pkg_man.run_command("invenio", "index", "init"),
+                cmd=pkg_man.send_command("invenio", "index", "init"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating indices...",
             ),
@@ -192,7 +192,7 @@ class ServicesCommands(Commands):
                 steps.extend(
                     [
                         CommandStep(
-                            cmd=pkg_man.run_command(
+                            cmd=pkg_man.send_command(
                                 "invenio",
                                 "rdm-records",
                                 "custom-fields",
@@ -202,7 +202,7 @@ class ServicesCommands(Commands):
                             message="Creating custom fields for records...",
                         ),
                         CommandStep(
-                            cmd=pkg_man.run_command(
+                            cmd=pkg_man.send_command(
                                 "invenio",
                                 "communities",
                                 "custom-fields",
@@ -232,9 +232,10 @@ class ServicesCommands(Commands):
             )
 
         if ils_version():
-            cmd = pkg_man.run_command("invenio", "setup", "--verbose")
+            args = ["invenio", "setup", "--verbose"]
             if not demo_data:
-                cmd.append("--skip-demo-data")
+                args.append("--skip-demo-data")
+            cmd = pkg_man.send_command(*args)
             steps.extend(
                 [
                     CommandStep(
@@ -260,7 +261,7 @@ class ServicesCommands(Commands):
         pkg_man = self.cli_config.python_package_manager
         steps = [
             CommandStep(
-                cmd=pkg_man.run_command("invenio", "rdm-records", "demo"),
+                cmd=pkg_man.send_command("invenio", "rdm-records", "demo"),
                 env={"PIPENV_VERBOSITY": "-1"},
                 message="Creating demo records...",
             )
@@ -271,14 +272,14 @@ class ServicesCommands(Commands):
     def declare_queues(self):
         """Steps to declare the MQ queues required for statistics, etc."""
         pkg_man = self.cli_config.python_package_manager
-        command = pkg_man.run_command("invenio", "queues", "declare")
+        command = pkg_man.send_command("invenio", "queues", "declare")
         steps = [CommandStep(cmd=command, message="Declaring queues...")]
         return steps
 
     def fixtures(self):
         """Steps to set up the required fixtures for the instance."""
         pkg_man = self.cli_config.python_package_manager
-        command = pkg_man.run_command("invenio", "rdm-records", "fixtures")
+        command = pkg_man.send_command("invenio", "rdm-records", "fixtures")
         steps = [
             CommandStep(
                 cmd=command,
@@ -292,7 +293,7 @@ class ServicesCommands(Commands):
     def rdm_fixtures(self):
         """Steps to set up the rdm fixtures for the instance."""
         pkg_man = self.cli_config.python_package_manager
-        command = pkg_man.run_command("invenio", "rdm", "fixtures")
+        command = pkg_man.send_command("invenio", "rdm", "fixtures")
         steps = [
             CommandStep(
                 cmd=command,

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2020-2024 CERN.
 # SPDX-FileCopyrightText: 2021 Esteban J. G. Gabancho.
-# SPDX-FileCopyrightText: 2024 Graz University of Technology.
+# SPDX-FileCopyrightText: 2024-2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Invenio module to ease the creation and management of applications."""
@@ -186,7 +186,7 @@ class ServicesCommands(Commands):
             ),
         ]
 
-        rdm_version_value = rdm_version()
+        rdm_version_value = rdm_version(self.cli_config)
         if rdm_version_value:
             if rdm_version_value[0] >= 10:
                 steps.extend(

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -132,7 +132,7 @@ class ServicesCommands(Commands):
         """Build default location path based on file storage selection."""
         file_storage = self.cli_config.get_file_storage()
         if file_storage == "local":
-            return "{}/data".format(self.cli_config.get_instance_path())
+            return "{}/data".format(self.cli_config.get_data_path())
         return "{}://default".format(self.cli_config.get_file_storage().lower())
 
     def _setup(self, demo_data=False):

--- a/invenio_cli/commands/services.py
+++ b/invenio_cli/commands/services.py
@@ -38,7 +38,12 @@ class ServicesCommands(Commands):
             cmd_env = {"INSTANCE_PATH": str(instance_path)}
         # Set environment variable for the instance path, it might be needed by docker services
         with env(**cmd_env):
-            self.docker_helper.start_containers()
+            response = self.docker_helper.start_containers()
+        if response.status_code != 0:
+            return ProcessResponse(
+                error="Failed to start containers (see docker compose output above).",
+                status_code=1,
+            )
 
         services = ["redis", self.cli_config.get_db_type(), "search"]
         for service in services:

--- a/invenio_cli/commands/steps.py
+++ b/invenio_cli/commands/steps.py
@@ -5,6 +5,7 @@
 """Invenio module to ease the creation and management of applications."""
 
 from ..helpers.process import run_interactive
+from ..helpers.rpc import RPCCall, echo_output
 
 
 class Step(object):
@@ -57,5 +58,12 @@ class CommandStep(Step):
         self.log_file = log_file
 
     def execute(self):
-        """Execute the function with the given arguments."""
+        """Execute the command, either over RPC or as a subprocess."""
+        if isinstance(self.cmd, RPCCall):
+            response = self.cmd()
+            echo_output(response, log_file=self.log_file)
+            if response.status_code > 0 and self.skippable:
+                response.warning = True
+                response.status_code = 0
+            return response
         return run_interactive(self.cmd, self.env, self.skippable, self.log_file)

--- a/invenio_cli/commands/steps.py
+++ b/invenio_cli/commands/steps.py
@@ -5,7 +5,6 @@
 """Invenio module to ease the creation and management of applications."""
 
 from ..helpers.process import run_interactive
-from ..helpers.rpc import RPCCall, echo_output
 
 
 class Step(object):
@@ -58,10 +57,9 @@ class CommandStep(Step):
         self.log_file = log_file
 
     def execute(self):
-        """Execute the command, either over RPC or as a subprocess."""
-        if isinstance(self.cmd, RPCCall):
-            response = self.cmd()
-            echo_output(response, log_file=self.log_file)
+        """Execute the command, an op (RPCOp/LocalOp) or a plain argv list."""
+        if callable(self.cmd):
+            response = self.cmd(env=self.env, log_file=self.log_file)
             if response.status_code > 0 and self.skippable:
                 response.warning = True
                 response.status_code = 0

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2019-2024 CERN.
 # SPDX-FileCopyrightText: 2019-2020 Northwestern University.
 # SPDX-FileCopyrightText: 2021 Esteban J. G. Gabancho.
-# SPDX-FileCopyrightText: 2024 Graz University of Technology.
+# SPDX-FileCopyrightText: 2024-2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Invenio-cli configuration file."""
@@ -145,6 +145,10 @@ class CLIConfig(object):
     def get_project_shortname(self):
         """Returns the project's shortname."""
         return self.config[CLIConfig.COOKIECUTTER_SECTION]["project_shortname"]
+
+    def get_rpc_server_port(self):
+        """Returns rpc server port."""
+        return self.private_config[CLIConfig.CLI_SECTION].get("rpc_port", "5001")
 
     def get_search_port(self):
         """Returns the search port."""

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -101,6 +101,14 @@ class CLIConfig(object):
         """Returns path to project directory."""
         return self.config_path.parent.resolve()
 
+    def get_data_path(self):
+        """Return path to data."""
+        path = self.private_config[CLIConfig.CLI_SECTION].get("data_path")
+        if path:
+            return Path(path)
+        else:
+            return self.get_instance_path()
+
     def get_instance_path(self, throw=True):
         """Returns path to application instance directory.
 

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2019-2024 CERN.
 # SPDX-FileCopyrightText: 2019-2020 Northwestern University.
 # SPDX-FileCopyrightText: 2021 Esteban J. G. Gabancho.
-# SPDX-FileCopyrightText: 2024-2025 Graz University of Technology.
+# SPDX-FileCopyrightText: 2024-2026 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Invenio-cli configuration file."""
@@ -70,15 +70,17 @@ class CLIConfig(object):
     def python_package_manager(self) -> PythonPackageManager:
         """Get python packages manager."""
         manager_name = self.config[CLIConfig.CLI_SECTION].get("python_package_manager")
+        use_rpc = self.config[CLIConfig.CLI_SECTION].get("use_rpc", False)
+
         if manager_name == Pipenv.name:
-            return Pipenv()
+            return Pipenv(use_rpc=use_rpc)
         elif manager_name == UV.name:
-            return UV()
+            return UV(use_rpc=use_rpc)
 
         if (self.project_path / "Pipfile").is_file():
-            return Pipenv()
+            return Pipenv(use_rpc=use_rpc)
         elif (self.project_path / "pyproject.toml").is_file():
-            return UV()
+            return UV(use_rpc=use_rpc)
         else:
             raise RuntimeError(
                 "Could not determine the Python package manager, please configure it."

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -177,6 +177,10 @@ class CLIConfig(object):
         """Returns web host."""
         return self.private_config[CLIConfig.CLI_SECTION].get("web_host", "127.0.0.1")
 
+    def get_app_rdm_version(self):
+        """Returns app rdm version."""
+        return self.private_config[CLIConfig.CLI_SECTION].get("app_rdm", None)
+
     def get_db_type(self):
         """Returns the database type (mysql, postgresql)."""
         return self.config[CLIConfig.COOKIECUTTER_SECTION]["database"]

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -71,16 +71,19 @@ class CLIConfig(object):
         """Get python packages manager."""
         manager_name = self.config[CLIConfig.CLI_SECTION].get("python_package_manager")
         use_rpc = self.config[CLIConfig.CLI_SECTION].get("use_rpc", False)
+        # the socket lives in the instance directory, so RPC only kicks in
+        # once the instance path is known (i.e. after the first install)
+        rpc_socket_path = self.get_rpc_socket_path() if use_rpc else None
 
         if manager_name == Pipenv.name:
-            return Pipenv(use_rpc=use_rpc)
+            return Pipenv(rpc_socket_path=rpc_socket_path)
         elif manager_name == UV.name:
-            return UV(use_rpc=use_rpc)
+            return UV(rpc_socket_path=rpc_socket_path)
 
         if (self.project_path / "Pipfile").is_file():
-            return Pipenv(use_rpc=use_rpc)
+            return Pipenv(rpc_socket_path=rpc_socket_path)
         elif (self.project_path / "pyproject.toml").is_file():
-            return UV(use_rpc=use_rpc)
+            return UV(rpc_socket_path=rpc_socket_path)
         else:
             raise RuntimeError(
                 "Could not determine the Python package manager, please configure it."
@@ -159,6 +162,12 @@ class CLIConfig(object):
     def get_rpc_server_port(self):
         """Returns rpc server port."""
         return self.private_config[CLIConfig.CLI_SECTION].get("rpc_port", "5001")
+
+    def get_rpc_socket_path(self):
+        """Returns the RPC socket path (None until the instance path is set)."""
+        instance_path = self.get_instance_path(throw=False)
+        if instance_path:
+            return instance_path / "rpc.sock"
 
     def get_search_port(self):
         """Returns the search port."""

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -73,19 +73,20 @@ class CLIConfig(object):
         use_rpc = self.config[CLIConfig.CLI_SECTION].getboolean(
             "use_rpc", fallback=False
         )
-        # the socket lives in the instance directory, so RPC only kicks in
-        # once the instance path is known (i.e. after the first install)
-        rpc_socket_path = self.get_rpc_socket_path() if use_rpc else None
+        # passed as a callable: the socket lives in the instance directory,
+        # which install only discovers partway through, and RPC should kick
+        # in from that moment on
+        get_socket_path = self.get_rpc_socket_path if use_rpc else None
 
         if manager_name == Pipenv.name:
-            return Pipenv(rpc_socket_path=rpc_socket_path)
+            return Pipenv(get_rpc_socket_path=get_socket_path)
         elif manager_name == UV.name:
-            return UV(rpc_socket_path=rpc_socket_path)
+            return UV(get_rpc_socket_path=get_socket_path)
 
         if (self.project_path / "Pipfile").is_file():
-            return Pipenv(rpc_socket_path=rpc_socket_path)
+            return Pipenv(get_rpc_socket_path=get_socket_path)
         elif (self.project_path / "pyproject.toml").is_file():
-            return UV(rpc_socket_path=rpc_socket_path)
+            return UV(get_rpc_socket_path=get_socket_path)
         else:
             raise RuntimeError(
                 "Could not determine the Python package manager, please configure it."

--- a/invenio_cli/helpers/cli_config.py
+++ b/invenio_cli/helpers/cli_config.py
@@ -70,7 +70,9 @@ class CLIConfig(object):
     def python_package_manager(self) -> PythonPackageManager:
         """Get python packages manager."""
         manager_name = self.config[CLIConfig.CLI_SECTION].get("python_package_manager")
-        use_rpc = self.config[CLIConfig.CLI_SECTION].get("use_rpc", False)
+        use_rpc = self.config[CLIConfig.CLI_SECTION].getboolean(
+            "use_rpc", fallback=False
+        )
         # the socket lives in the instance directory, so RPC only kicks in
         # once the instance path is known (i.e. after the first install)
         rpc_socket_path = self.get_rpc_socket_path() if use_rpc else None
@@ -158,10 +160,6 @@ class CLIConfig(object):
     def get_project_shortname(self):
         """Returns the project's shortname."""
         return self.config[CLIConfig.COOKIECUTTER_SECTION]["project_shortname"]
-
-    def get_rpc_server_port(self):
-        """Returns rpc server port."""
-        return self.private_config[CLIConfig.CLI_SECTION].get("rpc_port", "5001")
 
     def get_rpc_socket_path(self):
         """Returns the RPC socket path (None until the instance path is set)."""

--- a/invenio_cli/helpers/docker_helper.py
+++ b/invenio_cli/helpers/docker_helper.py
@@ -90,7 +90,8 @@ class DockerHelper(object):
         if app_only:
             command.extend(["web-ui", "web-api"])
 
-        return run_cmd(command)
+        # interactive so image pulls and container creation stream live
+        return run_interactive(command)
 
     def stop_containers(self):
         """Stop currently running containers."""

--- a/invenio_cli/helpers/package_managers.py
+++ b/invenio_cli/helpers/package_managers.py
@@ -46,25 +46,35 @@ class PythonPackageManager(ABC):
     name: str = None
     lock_file_name: str = None
 
-    def __init__(self, rpc_socket_path=None):
-        """Construct."""
+    def __init__(self, get_rpc_socket_path=None):
+        """Construct.
+
+        ``get_rpc_socket_path`` is a zero-argument callable returning the
+        RPC socket path, or None while it is unknown. A callable because
+        the socket lives in the instance directory, which is only
+        discovered partway through the first install.
+        """
+        self._get_rpc_socket_path = get_rpc_socket_path
         self.rpc = None
-        if rpc_socket_path:
-            self.rpc = RPCClient(
-                rpc_socket_path,
-                self.run_command(
-                    "invenio", "rpc-server", "start", "--socket", str(rpc_socket_path)
-                ),
-            )
 
     def invenio_command(self, *command):
         """Build an executable op for the given invenio CLI command.
 
-        Returns an ``RPCOp`` when the RPC server is enabled, otherwise a
-        ``LocalOp`` running the command as a subprocess — both with the
-        same call shape. Only use this for short-lived, non-interactive
-        ``invenio`` commands; anything else goes through ``run_command``.
+        Returns an ``RPCOp`` when the RPC server is enabled and its socket
+        path is known, otherwise a ``LocalOp`` running the command as a
+        subprocess, both with the same call shape. Only use this for
+        short-lived, non-interactive ``invenio`` commands; anything else
+        goes through ``run_command``.
         """
+        if self.rpc is None and self._get_rpc_socket_path:
+            socket_path = self._get_rpc_socket_path()
+            if socket_path:
+                self.rpc = RPCClient(
+                    socket_path,
+                    self.run_command(
+                        "invenio", "rpc-server", "start", "--socket", str(socket_path)
+                    ),
+                )
         if self.rpc:
             # drop the leading "invenio"; the server routes the argv itself
             return RPCOp(self.rpc, command[1:])

--- a/invenio_cli/helpers/package_managers.py
+++ b/invenio_cli/helpers/package_managers.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2025 TU Wien.
-# SPDX-FileCopyrightText: 2025 Graz University of Technology.
+# SPDX-FileCopyrightText: 2025-2026 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Wrappers around various package managers to be used under the hood."""
@@ -28,8 +28,15 @@ class PythonPackageManager(ABC):
     rpc_server: Popen = None
     run_prefix: List = []
 
+    def __init__(self, use_rpc=False):
+        """Construct."""
+        self.use_rpc = use_rpc
+
     def ensure_rpc_server_is_running(self):
         """Ensure rpc server is running."""
+        if not self.use_rpc:
+            return
+
         if self.rpc_server_is_running:
             return
 

--- a/invenio_cli/helpers/package_managers.py
+++ b/invenio_cli/helpers/package_managers.py
@@ -1,18 +1,22 @@
 # SPDX-FileCopyrightText: 2025 TU Wien.
+# SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Wrappers around various package managers to be used under the hood."""
 
+import atexit
 import os
 from abc import ABC
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from subprocess import Popen
 from typing import Dict, List, Union
 
 from pynpm import NPMPackage, PNPMPackage
 
 from ..helpers.process import ProcessResponse
+from .process import run_cmd
 
 
 class PythonPackageManager(ABC):
@@ -20,6 +24,40 @@ class PythonPackageManager(ABC):
 
     name: str = None
     lock_file_name: str = None
+    rpc_server_is_running: bool = False
+    rpc_server: Popen = None
+    run_prefix: List = []
+
+    def ensure_rpc_server_is_running(self):
+        """Ensure rpc server is running."""
+        if self.rpc_server_is_running:
+            return
+
+        # first check if a server is already running. so to use long running rpc server
+        response = run_cmd(self.run_prefix + ["rpc-server", "ping", "--port", "5001"])
+        if "pong" in response.output:
+            self.rpc_server_is_running = True
+            return
+
+        # open if not
+        self.rpc_server = Popen(
+            self.run_prefix + ["invenio", "rpc-server", "start", "--port", "5001"]
+        )
+
+        atexit.register(self.cleanup)
+        # check until the server is up and running
+        while True:
+            response = run_cmd(
+                self.run_prefix + ["rpc-server", "ping", "--port", "5001"]
+            )
+            if "pong" in response.output:
+                self.rpc_server_is_running = True
+                break
+
+    def cleanup(self):
+        """Cleanup."""
+        if self.rpc_server:
+            self.rpc_server.terminate()
 
     def run_command(self, *command: str) -> List[str]:
         """Generate command to run the given command in the managed environment."""
@@ -63,6 +101,26 @@ class Pipenv(PythonPackageManager):
 
     name = "pipenv"
     lock_file_name = "Pipfile.lock"
+    run_prefix = ["pipenv", "run"]
+
+    def send_command(self, *command):
+        """Send command to rpc server, default to run_command."""
+        self.ensure_rpc_server_is_running()
+
+        if self.rpc_server_is_running:
+            # [1:] remove "invenio" from commands
+            return [
+                self.name,
+                "run",
+                "rpc-server",
+                "send",
+                "--port",
+                "5001",
+                "--plain",
+                *command[1:],
+            ]
+        else:
+            self.run_command(*command)
 
     def run_command(self, *command):
         """Generate command to run the given command in the managed environment."""
@@ -120,6 +178,27 @@ class UV(PythonPackageManager):
 
     name = "uv"
     lock_file_name = "uv.lock"
+    run_prefix = ["uv", "run", "--no-sync"]
+
+    def send_command(self, *command):
+        """Send command to rpc server, default to run_command."""
+        self.ensure_rpc_server_is_running()
+
+        if self.rpc_server_is_running:
+            # [1:] remove "invenio" from commands
+            return [
+                self.name,
+                "run",
+                "--no-sync",
+                "rpc-server",
+                "send",
+                "--port",
+                "5001",
+                "--plain",
+                *command[1:],
+            ]
+        else:
+            return self.run_command(*command)
 
     def run_command(self, *command):
         """Generate command to run the given command in the managed environment."""

--- a/invenio_cli/helpers/package_managers.py
+++ b/invenio_cli/helpers/package_managers.py
@@ -14,7 +14,30 @@ from typing import Dict, List, Union
 from pynpm import NPMPackage, PNPMPackage
 
 from ..helpers.process import ProcessResponse
-from .rpc import RPCCall, RPCClient
+from .process import run_cmd, run_interactive
+from .rpc import RPCClient, RPCOp
+
+
+class LocalOp:
+    """Executable invenio command op that runs as a subprocess.
+
+    The RPC-less counterpart of ``RPCOp``, with the same call shape.
+    """
+
+    def __init__(self, argv):
+        """Construct."""
+        self.argv = list(argv)
+
+    @property
+    def label(self):
+        """Subcommand name, used for progress messages."""
+        return self.argv[-1]
+
+    def __call__(self, env=None, log_file=None, capture=False):
+        """Run the command and return a ProcessResponse."""
+        if capture:
+            return run_cmd(self.argv)
+        return run_interactive(self.argv, env=env, log_file=log_file)
 
 
 class PythonPackageManager(ABC):
@@ -34,12 +57,18 @@ class PythonPackageManager(ABC):
                 ),
             )
 
-    def send_command(self, *command):
-        """Build an executable op for the command, preferring the RPC server."""
+    def invenio_command(self, *command):
+        """Build an executable op for the given invenio CLI command.
+
+        Returns an ``RPCOp`` when the RPC server is enabled, otherwise a
+        ``LocalOp`` running the command as a subprocess — both with the
+        same call shape. Only use this for short-lived, non-interactive
+        ``invenio`` commands; anything else goes through ``run_command``.
+        """
         if self.rpc:
             # drop the leading "invenio"; the server routes the argv itself
-            return RPCCall(self.rpc, command[1:])
-        return self.run_command(*command)
+            return RPCOp(self.rpc, command[1:])
+        return LocalOp(self.run_command(*command))
 
     def run_command(self, *command: str) -> List[str]:
         """Generate command to run the given command in the managed environment."""

--- a/invenio_cli/helpers/package_managers.py
+++ b/invenio_cli/helpers/package_managers.py
@@ -4,19 +4,17 @@
 
 """Wrappers around various package managers to be used under the hood."""
 
-import atexit
 import os
 from abc import ABC
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from subprocess import Popen
 from typing import Dict, List, Union
 
 from pynpm import NPMPackage, PNPMPackage
 
 from ..helpers.process import ProcessResponse
-from .process import run_cmd
+from .rpc import RPCCall, RPCClient
 
 
 class PythonPackageManager(ABC):
@@ -24,47 +22,24 @@ class PythonPackageManager(ABC):
 
     name: str = None
     lock_file_name: str = None
-    rpc_server_is_running: bool = False
-    rpc_server: Popen = None
-    run_prefix: List = []
 
-    def __init__(self, use_rpc=False):
+    def __init__(self, rpc_socket_path=None):
         """Construct."""
-        self.use_rpc = use_rpc
-
-    def ensure_rpc_server_is_running(self):
-        """Ensure rpc server is running."""
-        if not self.use_rpc:
-            return
-
-        if self.rpc_server_is_running:
-            return
-
-        # first check if a server is already running. so to use long running rpc server
-        response = run_cmd(self.run_prefix + ["rpc-server", "ping", "--port", "5001"])
-        if "pong" in response.output:
-            self.rpc_server_is_running = True
-            return
-
-        # open if not
-        self.rpc_server = Popen(
-            self.run_prefix + ["invenio", "rpc-server", "start", "--port", "5001"]
-        )
-
-        atexit.register(self.cleanup)
-        # check until the server is up and running
-        while True:
-            response = run_cmd(
-                self.run_prefix + ["rpc-server", "ping", "--port", "5001"]
+        self.rpc = None
+        if rpc_socket_path:
+            self.rpc = RPCClient(
+                rpc_socket_path,
+                self.run_command(
+                    "invenio", "rpc-server", "start", "--socket", str(rpc_socket_path)
+                ),
             )
-            if "pong" in response.output:
-                self.rpc_server_is_running = True
-                break
 
-    def cleanup(self):
-        """Cleanup."""
-        if self.rpc_server:
-            self.rpc_server.terminate()
+    def send_command(self, *command):
+        """Build an executable op for the command, preferring the RPC server."""
+        if self.rpc:
+            # drop the leading "invenio"; the server routes the argv itself
+            return RPCCall(self.rpc, command[1:])
+        return self.run_command(*command)
 
     def run_command(self, *command: str) -> List[str]:
         """Generate command to run the given command in the managed environment."""
@@ -108,26 +83,6 @@ class Pipenv(PythonPackageManager):
 
     name = "pipenv"
     lock_file_name = "Pipfile.lock"
-    run_prefix = ["pipenv", "run"]
-
-    def send_command(self, *command):
-        """Send command to rpc server, default to run_command."""
-        self.ensure_rpc_server_is_running()
-
-        if self.rpc_server_is_running:
-            # [1:] remove "invenio" from commands
-            return [
-                self.name,
-                "run",
-                "rpc-server",
-                "send",
-                "--port",
-                "5001",
-                "--plain",
-                *command[1:],
-            ]
-        else:
-            self.run_command(*command)
 
     def run_command(self, *command):
         """Generate command to run the given command in the managed environment."""
@@ -185,27 +140,6 @@ class UV(PythonPackageManager):
 
     name = "uv"
     lock_file_name = "uv.lock"
-    run_prefix = ["uv", "run", "--no-sync"]
-
-    def send_command(self, *command):
-        """Send command to rpc server, default to run_command."""
-        self.ensure_rpc_server_is_running()
-
-        if self.rpc_server_is_running:
-            # [1:] remove "invenio" from commands
-            return [
-                self.name,
-                "run",
-                "--no-sync",
-                "rpc-server",
-                "send",
-                "--port",
-                "5001",
-                "--plain",
-                *command[1:],
-            ]
-        else:
-            return self.run_command(*command)
 
     def run_command(self, *command):
         """Generate command to run the given command in the managed environment."""

--- a/invenio_cli/helpers/rpc.py
+++ b/invenio_cli/helpers/rpc.py
@@ -43,7 +43,6 @@ class RPCClient:
         self.socket_path = str(socket_path)
         self.start_command = start_command
         self.server = None
-        self.available = False
 
     def request(self, payload, fds=None, read_timeout=None):
         """Send one JSON line (and fds) and read back one JSON-line response."""
@@ -71,31 +70,44 @@ class RPCClient:
             return False
         return response.get("pong") is True
 
-    def ensure_running(self, env=None):
-        """Start a server if none answers; return an error message or None.
+    def listening(self):
+        """Return whether something accepts connections on the socket.
 
-        ``env`` is added to the spawned server's environment, so it lands in
-        the app config the server builds at startup (e.g. ``INVENIO_*``
-        variables). It cannot be applied to an already running server.
+        Unlike ``ping`` this does not need the server to respond, so it
+        also recognizes a server that is busy running a long command.
         """
-        if self.available:
-            return None
-        if self.ping():
-            self.available = True
-            return None
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+                s.settimeout(CONNECT_TIMEOUT)
+                s.connect(self.socket_path)
+            return True
+        except OSError:
+            return False
 
+    def ensure_running(self, env=None):
+        """Spawn a server and wait until its socket accepts connections.
+
+        Returns an error message, or None on success. The server binds the
+        socket only after its app is fully created, so accepting
+        connections means ready. ``env`` is added to the spawned server's
+        environment, so it lands in the app config the server builds at
+        startup (e.g. ``INVENIO_*`` variables).
+        """
         self.server = Popen(self.start_command, env={**os.environ, **(env or {})})
         atexit.register(self.shutdown)
         deadline = time.monotonic() + STARTUP_TIMEOUT
         while time.monotonic() < deadline:
+            if self.listening():
+                return None
             if self.server.poll() is not None:
+                # our spawn may have lost a race against another invenio-cli
+                # whose server now owns the socket — that is still a success
+                if self.listening():
+                    return None
                 return (
                     "RPC server exited with code "
                     f"{self.server.returncode} during startup."
                 )
-            if self.ping():
-                self.available = True
-                return None
             time.sleep(0.2)
 
         self.shutdown()
@@ -104,42 +116,51 @@ class RPCClient:
     def call(self, argv, env=None, log_file=None, capture=False):
         """Run an invenio CLI command on the server.
 
-        By default the command's output streams live to this process'
-        stdout/stderr (or into ``log_file``) via the passed descriptors.
-        With ``capture`` the output is returned on the response instead.
-        ``env`` only takes effect if this call spawns the server.
+        The request is sent directly: a busy single-threaded server queues
+        the connection until it is free, and only a refused or missing
+        socket makes the client spawn a server (with ``env`` applied to it)
+        and retry once. By default the command's output streams live to
+        this process' stdout/stderr (or into ``log_file``) via the passed
+        descriptors; with ``capture`` it is returned on the response.
         """
-        error = self.ensure_running(env=env)
-        if error:
-            return ProcessResponse(error=error, status_code=1)
-
-        payload = {"argv": list(argv)}
         try:
-            if capture:
-                response = self.request(payload)
-                return ProcessResponse(
-                    output=response["stdout"],
-                    error=response["stderr"],
-                    status_code=response["exit_code"],
-                )
-
-            # flush so our own pending output stays ordered with the
-            # command output the server writes to the same descriptors
-            sys.stdout.flush()
-            sys.stderr.flush()
-            if log_file:
-                with open(log_file, "ab") as f:
-                    response = self.request(payload, fds=[f.fileno(), f.fileno()])
-            else:
-                response = self.request(
-                    payload, fds=[sys.stdout.fileno(), sys.stderr.fileno()]
-                )
-            return ProcessResponse(
-                error=response.get("stderr"),
-                status_code=response["exit_code"],
-            )
+            try:
+                return self.request_command(argv, log_file, capture)
+            except (FileNotFoundError, ConnectionRefusedError):
+                # nothing is listening on the socket
+                error = self.ensure_running(env=env)
+                if error:
+                    return ProcessResponse(error=error, status_code=1)
+                return self.request_command(argv, log_file, capture)
         except (OSError, ValueError) as e:
             return ProcessResponse(error=f"RPC request failed: {e}", status_code=1)
+
+    def request_command(self, argv, log_file=None, capture=False):
+        """Send one command request to a listening server."""
+        payload = {"argv": list(argv)}
+        if capture:
+            response = self.request(payload)
+            return ProcessResponse(
+                output=response["stdout"],
+                error=response["stderr"],
+                status_code=response["exit_code"],
+            )
+
+        # flush so our own pending output stays ordered with the
+        # command output the server writes to the same descriptors
+        sys.stdout.flush()
+        sys.stderr.flush()
+        if log_file:
+            with open(log_file, "ab") as f:
+                response = self.request(payload, fds=[f.fileno(), f.fileno()])
+        else:
+            response = self.request(
+                payload, fds=[sys.stdout.fileno(), sys.stderr.fileno()]
+            )
+        return ProcessResponse(
+            error=response.get("stderr"),
+            status_code=response["exit_code"],
+        )
 
     def shutdown(self):
         """Terminate the server if this process spawned it."""

--- a/invenio_cli/helpers/rpc.py
+++ b/invenio_cli/helpers/rpc.py
@@ -7,36 +7,26 @@
 The server (``invenio rpc-server start``) listens on a Unix domain socket
 and runs invenio CLI commands in a long-lived process, so each command
 skips the Python startup and app creation cost. The protocol is one JSON
-line per request (``{"argv": [...]}``) answered by one JSON line
-(``{"exit_code": ..., "stdout": ..., "stderr": ...}``).
+line per request (``{"argv": [...]}``) answered by one JSON line. By
+default the client passes its stdout/stderr file descriptors with the
+request (SCM_RIGHTS), the server streams the command output straight to
+them, and the response carries only the exit code; without descriptors
+the response carries the captured output instead.
 """
 
+import array
 import atexit
 import json
 import socket
+import sys
 import time
 from subprocess import Popen, TimeoutExpired
-
-import click
 
 from .process import ProcessResponse
 
 CONNECT_TIMEOUT = 5
 PING_TIMEOUT = 2
 STARTUP_TIMEOUT = 120  # starting the server includes a full app creation
-
-
-def echo_output(response, log_file=None):
-    """Surface buffered RPC output like a locally run command would."""
-    if log_file:
-        with open(log_file, "a") as f:
-            f.write(response.output or "")
-            f.write(response.error or "")
-    else:
-        if response.output:
-            click.echo(response.output, nl=False)
-        if response.error:
-            click.echo(response.error, nl=False, err=True)
 
 
 class RPCClient:
@@ -54,12 +44,19 @@ class RPCClient:
         self.server = None
         self.available = False
 
-    def request(self, payload, read_timeout=None):
-        """Send one JSON line and read back one JSON-line response."""
+    def request(self, payload, fds=None, read_timeout=None):
+        """Send one JSON line (and fds) and read back one JSON-line response."""
+        line = json.dumps(payload).encode("utf-8") + b"\n"
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
             s.settimeout(CONNECT_TIMEOUT)
             s.connect(self.socket_path)
-            s.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+            if fds:
+                s.sendmsg(
+                    [line],
+                    [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))],
+                )
+            else:
+                s.sendall(line)
             # commands may run for a long time (e.g. webpack builds)
             s.settimeout(read_timeout)
             with s.makefile("rb") as f:
@@ -98,22 +95,44 @@ class RPCClient:
         self.shutdown()
         return f"RPC server did not start within {STARTUP_TIMEOUT} seconds."
 
-    def call(self, argv):
-        """Run an invenio CLI command on the server."""
+    def call(self, argv, log_file=None, capture=False):
+        """Run an invenio CLI command on the server.
+
+        By default the command's output streams live to this process'
+        stdout/stderr (or into ``log_file``) via the passed descriptors.
+        With ``capture`` the output is returned on the response instead.
+        """
         error = self.ensure_running()
         if error:
             return ProcessResponse(error=error, status_code=1)
 
+        payload = {"argv": list(argv)}
         try:
-            response = self.request({"argv": list(argv)})
+            if capture:
+                response = self.request(payload)
+                return ProcessResponse(
+                    output=response["stdout"],
+                    error=response["stderr"],
+                    status_code=response["exit_code"],
+                )
+
+            # flush so our own pending output stays ordered with the
+            # command output the server writes to the same descriptors
+            sys.stdout.flush()
+            sys.stderr.flush()
+            if log_file:
+                with open(log_file, "ab") as f:
+                    response = self.request(payload, fds=[f.fileno(), f.fileno()])
+            else:
+                response = self.request(
+                    payload, fds=[sys.stdout.fileno(), sys.stderr.fileno()]
+                )
+            return ProcessResponse(
+                error=response.get("stderr"),
+                status_code=response["exit_code"],
+            )
         except (OSError, ValueError) as e:
             return ProcessResponse(error=f"RPC request failed: {e}", status_code=1)
-
-        return ProcessResponse(
-            output=response["stdout"],
-            error=response["stderr"],
-            status_code=response["exit_code"],
-        )
 
     def shutdown(self):
         """Terminate the server if this process spawned it."""
@@ -126,8 +145,12 @@ class RPCClient:
             self.server.kill()
 
 
-class RPCCall:
-    """Deferred RPC command that can be executed like a function step."""
+class RPCOp:
+    """Executable invenio command op that runs on the RPC server.
+
+    Has the same call shape as ``LocalOp`` so callers never branch on
+    which one they got.
+    """
 
     def __init__(self, client, argv):
         """Construct."""
@@ -139,6 +162,6 @@ class RPCCall:
         """Subcommand name, used for progress messages."""
         return self.argv[-1]
 
-    def __call__(self):
-        """Execute the command on the RPC server."""
-        return self.client.call(self.argv)
+    def __call__(self, env=None, log_file=None, capture=False):
+        """Execute on the RPC server; ``env`` is ignored (the server's applies)."""
+        return self.client.call(self.argv, log_file=log_file, capture=capture)

--- a/invenio_cli/helpers/rpc.py
+++ b/invenio_cli/helpers/rpc.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2025 Graz University of Technology.
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Client for the invenio RPC server.
+
+The server (``invenio rpc-server start``) listens on a Unix domain socket
+and runs invenio CLI commands in a long-lived process, so each command
+skips the Python startup and app creation cost. The protocol is one JSON
+line per request (``{"argv": [...]}``) answered by one JSON line
+(``{"exit_code": ..., "stdout": ..., "stderr": ...}``).
+"""
+
+import atexit
+import json
+import socket
+import time
+from subprocess import Popen, TimeoutExpired
+
+from .process import ProcessResponse
+
+CONNECT_TIMEOUT = 5
+PING_TIMEOUT = 2
+STARTUP_TIMEOUT = 120  # starting the server includes a full app creation
+
+
+class RPCClient:
+    """Talks to the invenio RPC server over its Unix domain socket.
+
+    If no server is listening, one is spawned on first use and terminated
+    again when invenio-cli exits; a server the user started themselves is
+    used but never owned.
+    """
+
+    def __init__(self, socket_path, start_command):
+        """Construct."""
+        self.socket_path = str(socket_path)
+        self.start_command = start_command
+        self.server = None
+        self.available = False
+
+    def request(self, payload, read_timeout=None):
+        """Send one JSON line and read back one JSON-line response."""
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(CONNECT_TIMEOUT)
+            s.connect(self.socket_path)
+            s.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+            # commands may run for a long time (e.g. webpack builds)
+            s.settimeout(read_timeout)
+            with s.makefile("rb") as f:
+                return json.loads(f.readline())
+
+    def ping(self):
+        """Return whether a server answers on the socket."""
+        try:
+            response = self.request({"ping": True}, read_timeout=PING_TIMEOUT)
+        except (OSError, ValueError):
+            return False
+        return response.get("pong") is True
+
+    def ensure_running(self):
+        """Start a server if none answers; return an error message or None."""
+        if self.available:
+            return None
+        if self.ping():
+            self.available = True
+            return None
+
+        self.server = Popen(self.start_command)
+        atexit.register(self.shutdown)
+        deadline = time.monotonic() + STARTUP_TIMEOUT
+        while time.monotonic() < deadline:
+            if self.server.poll() is not None:
+                return (
+                    "RPC server exited with code "
+                    f"{self.server.returncode} during startup."
+                )
+            if self.ping():
+                self.available = True
+                return None
+            time.sleep(0.2)
+
+        self.shutdown()
+        return f"RPC server did not start within {STARTUP_TIMEOUT} seconds."
+
+    def call(self, argv):
+        """Run an invenio CLI command on the server."""
+        error = self.ensure_running()
+        if error:
+            return ProcessResponse(error=error, status_code=1)
+
+        try:
+            response = self.request({"argv": list(argv)})
+        except (OSError, ValueError) as e:
+            return ProcessResponse(error=f"RPC request failed: {e}", status_code=1)
+
+        return ProcessResponse(
+            output=response["stdout"],
+            error=response["stderr"],
+            status_code=response["exit_code"],
+        )
+
+    def shutdown(self):
+        """Terminate the server if this process spawned it."""
+        if self.server is None or self.server.poll() is not None:
+            return
+        self.server.terminate()
+        try:
+            self.server.wait(timeout=10)
+        except TimeoutExpired:
+            self.server.kill()
+
+
+class RPCCall:
+    """Deferred RPC command that can be executed like a function step."""
+
+    def __init__(self, client, argv):
+        """Construct."""
+        self.client = client
+        self.argv = list(argv)
+
+    @property
+    def label(self):
+        """Subcommand name, used for progress messages."""
+        return self.argv[-1]
+
+    def __call__(self):
+        """Execute the command on the RPC server."""
+        return self.client.call(self.argv)

--- a/invenio_cli/helpers/rpc.py
+++ b/invenio_cli/helpers/rpc.py
@@ -17,11 +17,26 @@ import socket
 import time
 from subprocess import Popen, TimeoutExpired
 
+import click
+
 from .process import ProcessResponse
 
 CONNECT_TIMEOUT = 5
 PING_TIMEOUT = 2
 STARTUP_TIMEOUT = 120  # starting the server includes a full app creation
+
+
+def echo_output(response, log_file=None):
+    """Surface buffered RPC output like a locally run command would."""
+    if log_file:
+        with open(log_file, "a") as f:
+            f.write(response.output or "")
+            f.write(response.error or "")
+    else:
+        if response.output:
+            click.echo(response.output, nl=False)
+        if response.error:
+            click.echo(response.error, nl=False, err=True)
 
 
 class RPCClient:

--- a/invenio_cli/helpers/rpc.py
+++ b/invenio_cli/helpers/rpc.py
@@ -17,6 +17,7 @@ the response carries the captured output instead.
 import array
 import atexit
 import json
+import os
 import socket
 import sys
 import time
@@ -70,15 +71,20 @@ class RPCClient:
             return False
         return response.get("pong") is True
 
-    def ensure_running(self):
-        """Start a server if none answers; return an error message or None."""
+    def ensure_running(self, env=None):
+        """Start a server if none answers; return an error message or None.
+
+        ``env`` is added to the spawned server's environment, so it lands in
+        the app config the server builds at startup (e.g. ``INVENIO_*``
+        variables). It cannot be applied to an already running server.
+        """
         if self.available:
             return None
         if self.ping():
             self.available = True
             return None
 
-        self.server = Popen(self.start_command)
+        self.server = Popen(self.start_command, env={**os.environ, **(env or {})})
         atexit.register(self.shutdown)
         deadline = time.monotonic() + STARTUP_TIMEOUT
         while time.monotonic() < deadline:
@@ -95,14 +101,15 @@ class RPCClient:
         self.shutdown()
         return f"RPC server did not start within {STARTUP_TIMEOUT} seconds."
 
-    def call(self, argv, log_file=None, capture=False):
+    def call(self, argv, env=None, log_file=None, capture=False):
         """Run an invenio CLI command on the server.
 
         By default the command's output streams live to this process'
         stdout/stderr (or into ``log_file``) via the passed descriptors.
         With ``capture`` the output is returned on the response instead.
+        ``env`` only takes effect if this call spawns the server.
         """
-        error = self.ensure_running()
+        error = self.ensure_running(env=env)
         if error:
             return ProcessResponse(error=error, status_code=1)
 
@@ -163,5 +170,10 @@ class RPCOp:
         return self.argv[-1]
 
     def __call__(self, env=None, log_file=None, capture=False):
-        """Execute on the RPC server; ``env`` is ignored (the server's applies)."""
-        return self.client.call(self.argv, log_file=log_file, capture=capture)
+        """Execute on the RPC server.
+
+        ``env`` reaches the server's environment (and thus its app config)
+        only when this call is the one that spawns it; a server that is
+        already running keeps the environment it was started with.
+        """
+        return self.client.call(self.argv, env=env, log_file=log_file, capture=capture)

--- a/invenio_cli/helpers/rpc.py
+++ b/invenio_cli/helpers/rpc.py
@@ -26,7 +26,6 @@ from subprocess import Popen, TimeoutExpired
 from .process import ProcessResponse
 
 CONNECT_TIMEOUT = 5
-PING_TIMEOUT = 2
 STARTUP_TIMEOUT = 120  # starting the server includes a full app creation
 
 
@@ -44,7 +43,7 @@ class RPCClient:
         self.start_command = start_command
         self.server = None
 
-    def request(self, payload, fds=None, read_timeout=None):
+    def request(self, payload, fds=None):
         """Send one JSON line (and fds) and read back one JSON-line response."""
         line = json.dumps(payload).encode("utf-8") + b"\n"
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
@@ -58,22 +57,14 @@ class RPCClient:
             else:
                 s.sendall(line)
             # commands may run for a long time (e.g. webpack builds)
-            s.settimeout(read_timeout)
+            s.settimeout(None)
             with s.makefile("rb") as f:
                 return json.loads(f.readline())
-
-    def ping(self):
-        """Return whether a server answers on the socket."""
-        try:
-            response = self.request({"ping": True}, read_timeout=PING_TIMEOUT)
-        except (OSError, ValueError):
-            return False
-        return response.get("pong") is True
 
     def listening(self):
         """Return whether something accepts connections on the socket.
 
-        Unlike ``ping`` this does not need the server to respond, so it
+        A connect-only probe does not need the server to respond, so it
         also recognizes a server that is busy running a long command.
         """
         try:

--- a/invenio_cli/helpers/versions.py
+++ b/invenio_cli/helpers/versions.py
@@ -54,9 +54,14 @@ def _from_pyproject_toml(dep_name):
     return _parse_version(v.version)
 
 
-def rdm_version(cli_config):
-    """Return the latest RDM version."""
-    if app_rdm_version := cli_config.get_app_rdm_version():
+def rdm_version(cli_config=None):
+    """Return the latest RDM version.
+
+    A version pinned via the ``app_rdm`` option takes precedence, but
+    ``cli_config`` is optional: callers without a project context (e.g.
+    ``check-requirements``) fall back to the dependency files.
+    """
+    if cli_config and (app_rdm_version := cli_config.get_app_rdm_version()):
         return [int(v) for v in app_rdm_version.split(".")]
 
     elif os.path.isfile("./Pipfile"):

--- a/invenio_cli/helpers/versions.py
+++ b/invenio_cli/helpers/versions.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2022-2025 CERN.
 # SPDX-FileCopyrightText: 2025 TU Wien.
+# SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Invenio CLI dependencies helper."""
@@ -53,9 +54,12 @@ def _from_pyproject_toml(dep_name):
     return _parse_version(v.version)
 
 
-def rdm_version():
+def rdm_version(cli_config):
     """Return the latest RDM version."""
-    if os.path.isfile("./Pipfile"):
+    if app_rdm_version := cli_config.get_app_rdm_version():
+        return [int(v) for v in app_rdm_version.split(".")]
+
+    elif os.path.isfile("./Pipfile"):
         return _from_pipfile("invenio-app-rdm")
 
     elif os.path.isfile("./pyproject.toml"):

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -194,11 +194,20 @@ def test_concurrent_calls_queue_behind_a_busy_server(rpc_socket):
 
 def test_invenio_command_builds_an_rpc_op(short_tmp_path):
     """With a socket path, invenio_command defers to the RPC server."""
-    manager = UV(rpc_socket_path=short_tmp_path / "rpc.sock")
+    manager = UV(get_rpc_socket_path=lambda: short_tmp_path / "rpc.sock")
     op = manager.invenio_command("invenio", "webpack", "build")
     assert isinstance(op, RPCOp)
     assert op.argv == ["webpack", "build"]
     assert op.label == "build"
+
+
+def test_invenio_command_picks_up_a_late_socket_path(short_tmp_path):
+    """RPC kicks in once install discovers the instance path."""
+    socket_path = None
+    manager = UV(get_rpc_socket_path=lambda: socket_path)
+    assert isinstance(manager.invenio_command("invenio", "collect"), LocalOp)
+    socket_path = short_tmp_path / "rpc.sock"
+    assert isinstance(manager.invenio_command("invenio", "collect"), RPCOp)
 
 
 def test_invenio_command_without_rpc_builds_a_local_op():

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""RPC client tests."""
+
+import json
+import socketserver
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+from invenio_cli.helpers.package_managers import UV
+from invenio_cli.helpers.rpc import RPCCall, RPCClient
+
+
+class FakeInvenioHandler(socketserver.StreamRequestHandler):
+    """Respond to the RPC protocol like the invenio RPC server."""
+
+    def handle(self):
+        """Answer one JSON-line request with one JSON-line response."""
+        request = json.loads(self.rfile.readline())
+        if request.get("ping"):
+            response = {"pong": True}
+        else:
+            response = {
+                "exit_code": 7,
+                "stdout": " ".join(request["argv"]),
+                "stderr": "warning\n",
+            }
+        self.wfile.write(json.dumps(response).encode("utf-8") + b"\n")
+
+
+@pytest.fixture()
+def short_tmp_path():
+    """A directory short enough for AF_UNIX paths (~104 bytes on macOS)."""
+    with tempfile.TemporaryDirectory(prefix="rpc", dir="/tmp") as tmp:
+        yield Path(tmp)
+
+
+@pytest.fixture()
+def rpc_socket(short_tmp_path):
+    """A running protocol server on a temporary socket."""
+    socket_path = short_tmp_path / "rpc.sock"
+    server = socketserver.UnixStreamServer(str(socket_path), FakeInvenioHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield socket_path
+    server.shutdown()
+    server.server_close()
+
+
+def test_ping(rpc_socket):
+    """Ping detects a running server."""
+    assert RPCClient(rpc_socket, start_command=None).ping() is True
+
+
+def test_ping_without_server(short_tmp_path):
+    """Ping without a server is False, not an error."""
+    client = RPCClient(short_tmp_path / "nope.sock", start_command=None)
+    assert client.ping() is False
+
+
+def test_call_maps_the_response_to_a_process_response(rpc_socket):
+    """Exit code, stdout and stderr come back as a ProcessResponse."""
+    client = RPCClient(rpc_socket, start_command=None)
+    response = client.call(["webpack", "build"])
+    assert response.output == "webpack build"
+    assert response.error == "warning\n"
+    assert response.status_code == 7
+
+
+# A stand-in for "invenio rpc-server start": serves the protocol on the
+# socket given as first argument until it is terminated.
+SERVER_SCRIPT = """
+import json, socketserver, sys
+
+class Handler(socketserver.StreamRequestHandler):
+    def handle(self):
+        request = json.loads(self.rfile.readline())
+        if request.get("ping"):
+            response = {"pong": True}
+        else:
+            response = {"exit_code": 0, "stdout": "ok", "stderr": ""}
+        self.wfile.write(json.dumps(response).encode("utf-8") + b"\\n")
+
+with socketserver.UnixStreamServer(sys.argv[1], Handler) as server:
+    server.serve_forever()
+"""
+
+
+def test_call_spawns_and_terminates_a_server(short_tmp_path):
+    """Without a listening server, one is spawned, used and shut down."""
+    socket_path = short_tmp_path / "rpc.sock"
+    client = RPCClient(
+        socket_path, [sys.executable, "-c", SERVER_SCRIPT, str(socket_path)]
+    )
+    response = client.call(["collect"])
+    assert response.status_code == 0
+    assert response.output == "ok"
+    client.shutdown()
+    assert client.server.poll() is not None
+
+
+def test_call_reports_a_server_that_dies_during_startup(short_tmp_path):
+    """A start command that exits early fails the call instead of hanging."""
+    client = RPCClient(
+        short_tmp_path / "rpc.sock", [sys.executable, "-c", "raise SystemExit(3)"]
+    )
+    response = client.call(["collect"])
+    assert response.status_code == 1
+    assert "exited with code 3" in response.error
+
+
+def test_send_command_builds_an_rpc_call(short_tmp_path):
+    """With a socket path, send_command defers to the RPC server."""
+    manager = UV(rpc_socket_path=short_tmp_path / "rpc.sock")
+    op = manager.send_command("invenio", "webpack", "build")
+    assert isinstance(op, RPCCall)
+    assert op.argv == ["webpack", "build"]
+    assert op.label == "build"
+
+
+def test_send_command_without_rpc_is_the_plain_command():
+    """Without a socket path, send_command falls back to run_command."""
+    assert UV().send_command("invenio", "collect") == [
+        "uv",
+        "run",
+        "--no-sync",
+        "invenio",
+        "collect",
+    ]

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -11,6 +11,7 @@ import socketserver
 import sys
 import tempfile
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -45,6 +46,8 @@ class FakeInvenioHandler(socketserver.BaseRequestHandler):
         """Answer one JSON-line request with one JSON-line response."""
         line, fds = _recv_request(self.request)
         request = json.loads(line)
+        if request.get("argv") == ["slow"]:
+            time.sleep(0.3)  # simulate a long-running command
         if request.get("ping"):
             response = {"pong": True}
         elif fds:
@@ -176,6 +179,29 @@ def test_call_reports_a_server_that_dies_during_startup(short_tmp_path):
     response = client.call(["collect"])
     assert response.status_code == 1
     assert "exited with code 3" in response.error
+
+
+def test_spawn_race_loser_uses_the_listening_server(rpc_socket):
+    """A dead spawn is fine when another server owns the socket."""
+    client = RPCClient(rpc_socket, ["sh", "-c", "exit 9"])
+    assert client.ensure_running() is None
+
+
+def test_concurrent_calls_queue_behind_a_busy_server(rpc_socket):
+    """Calls connect directly and wait their turn instead of respawning."""
+    client = RPCClient(rpc_socket, start_command=None)
+    results = []
+
+    def run():
+        """Issue one slow captured call."""
+        results.append(client.call(["slow"], capture=True).status_code)
+
+    threads = [threading.Thread(target=run) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert results == [7, 7]
 
 
 def test_invenio_command_builds_an_rpc_op(short_tmp_path):

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from invenio_cli.commands.steps import CommandStep
 from invenio_cli.helpers.package_managers import UV
 from invenio_cli.helpers.rpc import RPCCall, RPCClient
 
@@ -132,3 +133,23 @@ def test_send_command_without_rpc_is_the_plain_command():
         "invenio",
         "collect",
     ]
+
+
+def test_command_step_executes_an_rpc_call(rpc_socket, capsys):
+    """CommandStep runs an RPCCall, surfaces output and the exit code."""
+    client = RPCClient(rpc_socket, start_command=None)
+    step = CommandStep(cmd=RPCCall(client, ["db", "init", "create"]))
+    response = step.execute()
+    assert response.status_code == 7
+    captured = capsys.readouterr()
+    assert captured.out == "db init create"
+    assert captured.err == "warning\n"
+
+
+def test_command_step_skippable_turns_rpc_failure_into_warning(rpc_socket):
+    """A skippable step reports a failed RPC command as a warning."""
+    client = RPCClient(rpc_socket, start_command=None)
+    step = CommandStep(cmd=RPCCall(client, ["db", "destroy"]), skippable=True)
+    response = step.execute()
+    assert response.status_code == 0
+    assert response.warning is True

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -45,12 +45,12 @@ class FakeInvenioHandler(socketserver.BaseRequestHandler):
     def handle(self):
         """Answer one JSON-line request with one JSON-line response."""
         line, fds = _recv_request(self.request)
+        if not line:
+            return  # connect-only liveness probe
         request = json.loads(line)
         if request.get("argv") == ["slow"]:
             time.sleep(0.3)  # simulate a long-running command
-        if request.get("ping"):
-            response = {"pong": True}
-        elif fds:
+        if fds:
             os.write(fds[0], b"streamed out\n")
             os.write(fds[1], b"streamed err\n")
             for fd in fds:
@@ -82,17 +82,6 @@ def rpc_socket(short_tmp_path):
     yield socket_path
     server.shutdown()
     server.server_close()
-
-
-def test_ping(rpc_socket):
-    """Ping detects a running server."""
-    assert RPCClient(rpc_socket, start_command=None).ping() is True
-
-
-def test_ping_without_server(short_tmp_path):
-    """Ping without a server is False, not an error."""
-    client = RPCClient(short_tmp_path / "nope.sock", start_command=None)
-    assert client.ping() is False
 
 
 def test_call_forwards_output_to_our_descriptors(rpc_socket, capfd):
@@ -131,15 +120,14 @@ import json, os, socketserver, sys
 
 class Handler(socketserver.StreamRequestHandler):
     def handle(self):
-        request = json.loads(self.rfile.readline())
-        if request.get("ping"):
-            response = {"pong": True}
-        else:
-            response = {
-                "exit_code": 0,
-                "stdout": os.environ.get("RPC_TEST_VAR", "ok"),
-                "stderr": "",
-            }
+        line = self.rfile.readline()
+        if not line:
+            return  # connect-only liveness probe
+        response = {
+            "exit_code": 0,
+            "stdout": os.environ.get("RPC_TEST_VAR", "ok"),
+            "stderr": "",
+        }
         self.wfile.write(json.dumps(response).encode("utf-8") + b"\\n")
 
 with socketserver.UnixStreamServer(sys.argv[1], Handler) as server:

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -3,7 +3,10 @@
 
 """RPC client tests."""
 
+import array
 import json
+import os
+import socket
 import socketserver
 import sys
 import tempfile
@@ -13,25 +16,50 @@ from pathlib import Path
 import pytest
 
 from invenio_cli.commands.steps import CommandStep
-from invenio_cli.helpers.package_managers import UV
-from invenio_cli.helpers.rpc import RPCCall, RPCClient
+from invenio_cli.helpers.package_managers import UV, LocalOp
+from invenio_cli.helpers.rpc import RPCClient, RPCOp
 
 
-class FakeInvenioHandler(socketserver.StreamRequestHandler):
+def _recv_request(sock):
+    """Read one JSON line plus any file descriptors sent with it."""
+    buf = b""
+    fds = []
+    fd_size = array.array("i").itemsize
+    while b"\n" not in buf:
+        data, ancdata, _, _ = sock.recvmsg(4096, socket.CMSG_SPACE(2 * fd_size))
+        if not data:
+            break
+        for level, ctype, cdata in ancdata:
+            if level == socket.SOL_SOCKET and ctype == socket.SCM_RIGHTS:
+                received = array.array("i")
+                received.frombytes(cdata[: len(cdata) - (len(cdata) % fd_size)])
+                fds.extend(received)
+        buf += data
+    return buf, fds
+
+
+class FakeInvenioHandler(socketserver.BaseRequestHandler):
     """Respond to the RPC protocol like the invenio RPC server."""
 
     def handle(self):
         """Answer one JSON-line request with one JSON-line response."""
-        request = json.loads(self.rfile.readline())
+        line, fds = _recv_request(self.request)
+        request = json.loads(line)
         if request.get("ping"):
             response = {"pong": True}
+        elif fds:
+            os.write(fds[0], b"streamed out\n")
+            os.write(fds[1], b"streamed err\n")
+            for fd in fds:
+                os.close(fd)
+            response = {"exit_code": 7}
         else:
             response = {
                 "exit_code": 7,
                 "stdout": " ".join(request["argv"]),
                 "stderr": "warning\n",
             }
-        self.wfile.write(json.dumps(response).encode("utf-8") + b"\n")
+        self.request.sendall(json.dumps(response).encode("utf-8") + b"\n")
 
 
 @pytest.fixture()
@@ -64,17 +92,36 @@ def test_ping_without_server(short_tmp_path):
     assert client.ping() is False
 
 
-def test_call_maps_the_response_to_a_process_response(rpc_socket):
-    """Exit code, stdout and stderr come back as a ProcessResponse."""
+def test_call_forwards_output_to_our_descriptors(rpc_socket, capfd):
+    """By default the command output streams to our stdout/stderr."""
     client = RPCClient(rpc_socket, start_command=None)
     response = client.call(["webpack", "build"])
+    assert response.status_code == 7
+    captured = capfd.readouterr()
+    assert captured.out == "streamed out\n"
+    assert captured.err == "streamed err\n"
+
+
+def test_call_forwards_output_to_a_log_file(rpc_socket, short_tmp_path):
+    """With a log file, the command output lands there instead."""
+    log_file = short_tmp_path / "build.log"
+    client = RPCClient(rpc_socket, start_command=None)
+    response = client.call(["webpack", "build"], log_file=str(log_file))
+    assert response.status_code == 7
+    assert log_file.read_text() == "streamed out\nstreamed err\n"
+
+
+def test_call_captures_output_on_request(rpc_socket):
+    """With capture, output comes back on the ProcessResponse."""
+    client = RPCClient(rpc_socket, start_command=None)
+    response = client.call(["webpack", "build"], capture=True)
     assert response.output == "webpack build"
     assert response.error == "warning\n"
     assert response.status_code == 7
 
 
-# A stand-in for "invenio rpc-server start": serves the protocol on the
-# socket given as first argument until it is terminated.
+# A stand-in for "invenio rpc-server start": serves the captured-output
+# protocol on the socket given as first argument until it is terminated.
 SERVER_SCRIPT = """
 import json, socketserver, sys
 
@@ -98,7 +145,7 @@ def test_call_spawns_and_terminates_a_server(short_tmp_path):
     client = RPCClient(
         socket_path, [sys.executable, "-c", SERVER_SCRIPT, str(socket_path)]
     )
-    response = client.call(["collect"])
+    response = client.call(["collect"], capture=True)
     assert response.status_code == 0
     assert response.output == "ok"
     client.shutdown()
@@ -115,41 +162,42 @@ def test_call_reports_a_server_that_dies_during_startup(short_tmp_path):
     assert "exited with code 3" in response.error
 
 
-def test_send_command_builds_an_rpc_call(short_tmp_path):
-    """With a socket path, send_command defers to the RPC server."""
+def test_invenio_command_builds_an_rpc_op(short_tmp_path):
+    """With a socket path, invenio_command defers to the RPC server."""
     manager = UV(rpc_socket_path=short_tmp_path / "rpc.sock")
-    op = manager.send_command("invenio", "webpack", "build")
-    assert isinstance(op, RPCCall)
+    op = manager.invenio_command("invenio", "webpack", "build")
+    assert isinstance(op, RPCOp)
     assert op.argv == ["webpack", "build"]
     assert op.label == "build"
 
 
-def test_send_command_without_rpc_is_the_plain_command():
-    """Without a socket path, send_command falls back to run_command."""
-    assert UV().send_command("invenio", "collect") == [
-        "uv",
-        "run",
-        "--no-sync",
-        "invenio",
-        "collect",
-    ]
+def test_invenio_command_without_rpc_builds_a_local_op():
+    """Without a socket path, invenio_command wraps the plain command."""
+    op = UV().invenio_command("invenio", "collect")
+    assert isinstance(op, LocalOp)
+    assert op.argv == ["uv", "run", "--no-sync", "invenio", "collect"]
+    assert op.label == "collect"
 
 
-def test_command_step_executes_an_rpc_call(rpc_socket, capsys):
-    """CommandStep runs an RPCCall, surfaces output and the exit code."""
+def test_local_op_runs_a_subprocess():
+    """LocalOp runs the argv and reports the real exit code."""
+    assert LocalOp(["sh", "-c", "exit 3"])().status_code == 3
+    assert LocalOp(["sh", "-c", "echo hi"])(capture=True).output == "hi\n"
+
+
+def test_command_step_executes_an_op(rpc_socket, capfd):
+    """CommandStep runs an op, with output forwarded and the exit code kept."""
     client = RPCClient(rpc_socket, start_command=None)
-    step = CommandStep(cmd=RPCCall(client, ["db", "init", "create"]))
+    step = CommandStep(cmd=RPCOp(client, ["db", "init", "create"]))
     response = step.execute()
     assert response.status_code == 7
-    captured = capsys.readouterr()
-    assert captured.out == "db init create"
-    assert captured.err == "warning\n"
+    assert capfd.readouterr().out == "streamed out\n"
 
 
-def test_command_step_skippable_turns_rpc_failure_into_warning(rpc_socket):
+def test_command_step_skippable_turns_op_failure_into_warning(rpc_socket, capfd):
     """A skippable step reports a failed RPC command as a warning."""
     client = RPCClient(rpc_socket, start_command=None)
-    step = CommandStep(cmd=RPCCall(client, ["db", "destroy"]), skippable=True)
+    step = CommandStep(cmd=RPCOp(client, ["db", "destroy"]), skippable=True)
     response = step.execute()
     assert response.status_code == 0
     assert response.warning is True

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -122,8 +122,9 @@ def test_call_captures_output_on_request(rpc_socket):
 
 # A stand-in for "invenio rpc-server start": serves the captured-output
 # protocol on the socket given as first argument until it is terminated.
+# Echoes RPC_TEST_VAR so tests can check the environment it was spawned with.
 SERVER_SCRIPT = """
-import json, socketserver, sys
+import json, os, socketserver, sys
 
 class Handler(socketserver.StreamRequestHandler):
     def handle(self):
@@ -131,7 +132,11 @@ class Handler(socketserver.StreamRequestHandler):
         if request.get("ping"):
             response = {"pong": True}
         else:
-            response = {"exit_code": 0, "stdout": "ok", "stderr": ""}
+            response = {
+                "exit_code": 0,
+                "stdout": os.environ.get("RPC_TEST_VAR", "ok"),
+                "stderr": "",
+            }
         self.wfile.write(json.dumps(response).encode("utf-8") + b"\\n")
 
 with socketserver.UnixStreamServer(sys.argv[1], Handler) as server:
@@ -150,6 +155,17 @@ def test_call_spawns_and_terminates_a_server(short_tmp_path):
     assert response.output == "ok"
     client.shutdown()
     assert client.server.poll() is not None
+
+
+def test_call_passes_env_to_the_spawned_server(short_tmp_path):
+    """env reaches the server's environment when this call spawns it."""
+    socket_path = short_tmp_path / "rpc.sock"
+    client = RPCClient(
+        socket_path, [sys.executable, "-c", SERVER_SCRIPT, str(socket_path)]
+    )
+    response = client.call(["collect"], env={"RPC_TEST_VAR": "hello"}, capture=True)
+    assert response.output == "hello"
+    client.shutdown()
 
 
 def test_call_reports_a_server_that_dies_during_startup(short_tmp_path):

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Version helper tests."""
+
+from invenio_cli.helpers.cli_config import CLIConfig
+from invenio_cli.helpers.versions import rdm_version
+
+
+def test_rdm_version_without_cli_config_reads_dependency_files(tmp_path, monkeypatch):
+    """Callers without a project context (check-requirements) stay valid."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "site"\ndependencies = ["invenio-app-rdm~=13.0.0"]\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    assert rdm_version() == [13, 0, 0]
+
+
+def test_rdm_version_prefers_the_pinned_version(tmp_path, monkeypatch):
+    """An app_rdm pin in the private config wins over dependency files."""
+    (tmp_path / ".invenio").write_text("[cli]\n")
+    (tmp_path / ".invenio.private").write_text("[cli]\napp_rdm = 14.1.0\n")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "site"\ndependencies = ["invenio-app-rdm~=13.0.0"]\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    assert rdm_version(CLIConfig(tmp_path)) == [14, 1, 0]


### PR DESCRIPTION
Depends on https://github.com/inveniosoftware/invenio-app/pull/113

- **feat: rpc-server**
  * use rpc-server which runs invenio commands. this is a performance
    enhancement
- **fix: warning**
- **README: add new features**
- **feat: add data path**
- **feat(config): configure app-rdm version**
  * usefull for beta.dev versions
- **feat(rpc): make the use configurable**

**refactor(rpc): talk to the RPC server directly over its socket**

* The client used to spawn a full `uv run rpc-server send` subprocess per command, paying the interpreter and import cost the server exists to avoid, and that subprocess always exited 0, so failed commands were reported as successful steps.
* `send_command()` now returns an `RPCCall` that speaks the JSON-lines protocol with stdlib socket+json and maps the response onto a `ProcessResponse`, so exit codes and stderr propagate and only the server needs the virtualenv.
* The server is spawned lazily when the first command executes (not while the step list is being built), probed with a bounded retry loop instead of busy-spinning subprocess pings, and terminated at exit only if this process started it.
* The socket lives at `<instance_path>/rpc.sock`, so RPC silently defers to plain commands until the instance path is known (first install).

**fix(rpc): parse use_rpc as a boolean and document the socket setup**

* configparser `.get()` returns the raw string, so `use_rpc = false` in the `.invenio` file still enabled RPC. Read it with `getboolean` instead.
* Drop the unused `rpc_port` option (the server no longer has a port) and update the README for the socket-based setup and the `use_rpc` flag.

**feat(rpc): let CommandStep execute RPC calls**

* `CommandStep` now accepts an `RPCCall` as its cmd: it executes it over the socket, surfaces the buffered output (terminal or log file, like `run_interactive` does), and applies the same skippable-to-warning mapping.
* This lets any step-based command switch to `send_command()` without changing the step plumbing.
* The output handling is shared with the assets loop via a new `echo_output()` helper.

**feat(rpc): route services setup through the RPC server**

* All invenio commands in `services setup` (including the `--force` cleanup and demo steps) now go through `send_command()`, so with `use_rpc` enabled the whole sequence runs on one long-lived server instead of paying app startup per command.
* Without `use_rpc` the behavior is unchanged.
* The pybabel translation steps stay as plain subprocesses since they are not invenio CLI commands.

**feat(rpc): stream output via fd passing and unify command ops**

* `invenio_command()` (formerly `send_command`) now always returns a callable op: `RPCOp` when the RPC server is in use, `LocalOp` wrapping a plain subprocess otherwise. Both take the same arguments, so callers no longer branch on whether they got an argv list or a callable.
* It is meant for short-lived, non-interactive invenio commands; everything else keeps using `run_command()`.
* `RPCOp` sends the client's stdout/stderr (or the log file) along with the request using SCM_RIGHTS, and the server writes command output directly to them. Output shows up live in the terminal or log file like with a normal subprocess, webpack builds included, which also fixes the `--node-log-file` regression.
* The captured-output mode is still available as `op(capture=True)` for callers that need the output programmatically, like `update_instance_path`.

**feat(rpc): apply env when spawning the server**

* `RPCOp` no longer drops env. It is added to the Popen environment when the call is the one that spawns the server, which is the only place it can take effect: `INVENIO_*` variables and `FLASK_DEBUG` become app config at `create_app` time, so the auto-spawned server picks up e.g. pnpm's `INVENIO_WEBPACKEXT_NPM_PKG_CLS` from the assets steps.
* Per-request env would not work, because the server caches the app and config-derived variables are only read at startup.
* A server that is already running keeps the environment it was started with, so setting `WEBPACKEXT_NPM_PKG_CLS` in `invenio.cfg` remains the safe option for pnpm.

**fix(rpc): connect directly instead of pinging before each call**

* The client no longer pings before sending: the single-threaded server queues the connection of a second client until the current command finishes, whereas the old 2s ping timeout made a busy server look absent and triggered a doomed second spawn.
* Only a refused or missing socket (nothing listening) now causes a spawn, probed with a cheap connect check that also recognizes a busy server.
* If the spawned server dies during startup, the client rechecks the socket before reporting failure, so losing a spawn race against another invenio-cli whose server won the socket is treated as success.

**fix(services): stream docker compose output and fail on errors**

* `start_containers()` captured the compose output through `run_cmd` and `ensure_containers_running()` discarded the response, so `docker compose up -d` showed nothing while pulling images for minutes and a compose failure only surfaced as a healthcheck timeout much later.
* The command now runs interactively (compose renders its live progress) and a non-zero exit fails the step immediately.

**fix(versions): make cli_config optional in rdm_version**

* The rebase that introduced the `app_rdm` version pin changed `rdm_version()` to require `cli_config`, but the call sites added upstream in the meantime (`run_jobs_scheduler`, containers setup, `check-requirements`) still called it bare and raised TypeError.
* The worst case was `invenio-cli run`: the crash happened after the web server and celery worker were already spawned, so invenio-cli died and orphaned both. That is why celery kept running after Ctrl+C.
* `cli_config` is now optional (`check-requirements` has no project context at all), the pin takes precedence when one is passed, and the callers that do have a config pass it.